### PR TITLE
Throw a config error when trying to define a non-existent layer

### DIFF
--- a/src/KMonad/Core/Config.hs
+++ b/src/KMonad/Core/Config.hs
@@ -53,8 +53,10 @@ import Control.Exception
 import Control.Lens
 import Control.Monad.Except
 import Control.Monad.ST
+import Data.Containers.ListUtils (nubOrd)
 import Data.Foldable (toList)
 import Data.Hashable
+import Data.List ((\\))
 import Data.Maybe
 import Data.STRef
 
@@ -89,6 +91,7 @@ data ConfigError
   | AnchorNotFound      KeyCode Name
   | AlignmentError      Coor    ButtonSymbol Name
   | AliasNotFound       Symbol  Name
+  | LayerNotFound       [Name]
   deriving Exception
 
 instance Show ConfigError where
@@ -136,6 +139,8 @@ instance Show ConfigError where
       , " not found in layer: "
       , show l
       ]
+  show (LayerNotFound ks)
+    = "Layer(s) not found: " <> show ks
 
 -- | Classy Prisms used to speak generally about 'ConfigError's
 makeClassyPrisms ''ConfigError
@@ -199,12 +204,33 @@ interpret (ConfigToken srcs lyrs alss is os)
       -- extract maps from all the provided layers
       ls <- mapM (\l -> (l^.layerName,) <$> extractMap src as l) lyrs
 
+      -- Extract layer names from aliases and button maps, checking for
+      -- non-existent names
+      let layerNames = nubOrd . concatMap getLayerName
+            $ M.elems as ++ concatMap (map snd . snd) ls
+          unknownNames = layerNames \\ map (^.layerName) lyrs
+      unless (null unknownNames) $
+        throwError $ _LayerNotFound # unknownNames
+
       pure $ Config
         { _mappings = ls
         , _input    = is !! 0
         , _output   = os !! 0
         , _entry    = (last $ lyrs) ^. layerName
         }
+
+-- | Extract named layers of a given button token
+getLayerName :: ButtonToken -> [Name]
+getLayerName bToken =
+  case bToken of
+    BLayerAdd n     -> [n]
+    BLayerRem n     -> [n]
+    BLayerToggle n  -> [n]
+    BTapHold _ b b' -> getLayerName b ++ getLayerName b'
+    BTapNext b b'   -> getLayerName b ++ getLayerName b'
+    BModded _ b     -> getLayerName b
+    BMultiTap msb   -> concatMap (getLayerName . snd) msb
+    _               -> []
 
 -- | Coregister a matrix of buttons to the source matrix
 extractMap :: CanComp e m

--- a/src/KMonad/Core/Parser/Token.hs
+++ b/src/KMonad/Core/Parser/Token.hs
@@ -94,7 +94,7 @@ data ButtonToken
   -- | BUnicode Unicode            -- ^ Corresponds to "KMonad.Domain.Button.SpecialSymbol"
   -- | BCompose Unicode            -- ^ Corresponds to "KMonad.Domain.Button.SpecialSymbol"
 
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 -- | A token describing anything that can be interpreted as a 'ButtonToken'
 data ButtonSymbol

--- a/src/KMonad/Core/SpecialSymbol.hs
+++ b/src/KMonad/Core/SpecialSymbol.hs
@@ -61,7 +61,7 @@ utfSequence = concatMap (tap . fromJust . kcFromChar) . utfString
 
 data DeadKey = DeadKey
   { _dkComposeSeq :: !(Maybe KeySequence)
-  } deriving (Eq, Show)
+  } deriving (Eq, Ord, Show)
 makeClassy ''DeadKey
 
 instance HasComposeSeq DeadKey where


### PR DESCRIPTION
This closes #8 by throwing an error if trying to specify a non-existent layer as either an alias or directly inside the layer configuration.

Caveats:
  1. I don't know the code base (nor lenses) particularly well, so this might not be the most straightforward way to do things.
  2. `\\` has a worst-case complexity of `O(n^2)`, which could make this part very slow for big configs (I don't know if this is actually a realistic case but I thought I'd mention it anyways).  A possible solution would be to try and implement a fast version of `\\` (It seems possible to write an `O(n log n)` version, given we have an `Ord` instance for `ButtonToken` now).  Alternatively it might make sense to rewrite everything as a `Set`.
3. Error messages are not particularly good.  Ideally there should be some context, giving the user a hint where the error approximately occurs. It might even make sense to just show the first error, not a list.