### PR TITLE
KMonad is now packaged for Void Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,17 @@ for an overview of different button-types.
 
 ## Getting KMonad
 
-KMonad is written in Haskell (with a tiny bit of C). You can either compile it
-yourself using the instructions mentioned below. Alternatively, the lovely
-people over at https://github.com/nh2/static-haskell-nix have helped me figure
-how to compile a static binary that should work basically on any standard 64-bit
-Linux system. You can find the most recent release [on the releases
+### On Void Linux
+You can install `kmonad` via `xbps-install`:
+``` shell
+xbps-install -S kmonad
+```
+
+### Binaries
+KMonad is written in Haskell (with a tiny bit of C). The lovely people over at
+https://github.com/nh2/static-haskell-nix have helped me figure how to compile a
+static binary that should work basically on any standard 64-bit Linux
+system. You can find the most recent release [on the releases
 page](https://github.com/david-janssen/kmonad/releases).
 
 ### Compiling


### PR DESCRIPTION
I've packaged KMonad (version 0.3.0) for [Void Linux](https://voidlinux.org/).  If you want to look at the template file you can find it [here](https://github.com/void-linux/void-packages/blob/master/srcpkgs/kmonad/template).  
This pr just edits the README (and slightly restructures the `Getting KMonad` section) to reflect this.