### PR TITLE
Mac support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Karabiner-VirtualHIDDevice"]
+	path = c_src/mac/Karabiner-VirtualHIDDevice
+	url = https://github.com/pqrs-org/Karabiner-VirtualHIDDevice.git

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KMonad
 
-Welcome to KMonad, a keyboard remapping utility for Linux and Windows.
+Welcome to KMonad, a keyboard remapping utility for Linux, Windows and Mac.
 
 The docs are not yet completed, but here they are anyways:
 - [installation](doc/installation.md)

--- a/c_src/mac/Makefile
+++ b/c_src/mac/Makefile
@@ -1,0 +1,2 @@
+all: list-keyboards.c
+	gcc $< -o list-keyboards -framework IOKit -framework CoreFoundation

--- a/c_src/mac/keyio_mac.cpp
+++ b/c_src/mac/keyio_mac.cpp
@@ -1,0 +1,354 @@
+#include <IOKit/hid/IOHIDLib.h>
+#include <IOKit/hidsystem/IOHIDShared.h>
+#include <unistd.h>
+#include <errno.h>
+#include <thread>
+#include <map>
+#include <iostream>
+
+#include "karabiner_virtual_hid_device_methods.hpp"
+
+/*
+ * Key event information that's shared between C++ and Haskell.
+ *
+ * type: represents key up or key down
+ *
+ * keycode: 16 uppermost bits represent IOKit usage page
+ *          16 lowermost bits represent IOKit usage
+ */
+struct KeyEvent {
+    uint8_t type;
+    uint32_t keycode;
+};
+
+/*
+ * Resources needed to post altered key events back to the OS. They
+ * are global so that they can be kept track of in the C++ code rather
+ * than in the Haskell.
+ */
+static mach_port_t connect;
+static io_service_t service;
+static pqrs::karabiner_virtual_hid_device::hid_report::keyboard_input keyboard;
+static pqrs::karabiner_virtual_hid_device::hid_report::apple_vendor_top_case_input top_case;
+static pqrs::karabiner_virtual_hid_device::hid_report::apple_vendor_keyboard_input apple_keyboard;
+static pqrs::karabiner_virtual_hid_device::hid_report::consumer_input consumer;
+
+/*
+ * These are needed to receive unaltered key events from the OS.
+ */
+static std::thread thread;
+static CFRunLoopRef listener_loop;
+static std::map<io_service_t,IOHIDDeviceRef> source_device;
+static int fd[2];
+static char *prod = nullptr;
+
+/*
+ * We'll register this callback to run whenever an IOHIDDevice
+ * (representing a keyboard) sends input from the user.
+ *
+ * It passes the relevant information into a pipe that will be read
+ * from with wait_key.
+ */
+void input_callback(void *context, IOReturn result, void *sender, IOHIDValueRef value) {
+    struct KeyEvent e;
+    CFIndex integer_value = IOHIDValueGetIntegerValue(value);
+    IOHIDElementRef element = IOHIDValueGetElement(value);
+    uint16_t usage_page = IOHIDElementGetUsagePage(element);
+    uint16_t usage = IOHIDElementGetUsage(element);
+    e.type = !integer_value;
+    e.keycode = (usage_page << 16) | usage;
+    write(fd[1], &e, sizeof(struct KeyEvent));
+}
+
+void open_matching_devices(char *product, io_iterator_t iter) {
+    io_name_t name;
+    kern_return_t kr;
+    CFStringRef cfproduct = NULL;
+    if(product) {
+        CFStringRef cfproduct = CFStringCreateWithCString(kCFAllocatorDefault, product, CFStringGetSystemEncoding());
+        if(cfproduct == NULL) {
+            std::cerr << "CFStringCreateWithCString error" << std::endl;
+            return;
+        }
+    }
+    CFStringRef cfkarabiner = CFStringCreateWithCString(kCFAllocatorDefault, "Karabiner VirtualHIDKeyboard", CFStringGetSystemEncoding());
+    if(cfkarabiner == NULL) {
+        std::cerr << "CFStringCreateWithCString error" << std::endl;
+        if(product) {
+            CFRelease(cfproduct);
+        }
+        return;
+    }
+    for(mach_port_t curr = IOIteratorNext(iter); curr; curr = IOIteratorNext(iter)) {
+        CFStringRef cfcurr = (CFStringRef)IORegistryEntryCreateCFProperty(curr, CFSTR(kIOHIDProductKey), kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+        if(cfcurr == NULL) {
+            std::cerr << "IORegistryEntryCreateCFProperty error" << std::endl;
+            CFRelease(cfcurr);
+            continue;
+        }
+        bool match = (CFStringCompare(cfcurr, cfkarabiner, 0) != kCFCompareEqualTo);
+        if(product) {
+            match = match && (CFStringCompare(cfcurr, cfproduct, 0) == kCFCompareEqualTo);
+        }
+        CFRelease(cfcurr);
+        if(!match) continue;
+        IOHIDDeviceRef dev = IOHIDDeviceCreate(kCFAllocatorDefault, curr);
+        source_device[curr] = dev;
+        IOHIDDeviceRegisterInputValueCallback(dev, input_callback, NULL);
+        kr = IOHIDDeviceOpen(dev, kIOHIDOptionsTypeSeizeDevice);
+        if(kr != kIOReturnSuccess) {
+            std::cerr << "IOHIDDeviceOpen error: " << std::hex << kr << std::endl;
+            if(kr == kIOReturnNotPrivileged) {
+                std::cerr << "IOHIDDeviceOpen requires root privileges when called with kIOHIDOptionsTypeSeizeDevice" << std::endl;
+            }
+        }
+        IOHIDDeviceScheduleWithRunLoop(dev, listener_loop, kCFRunLoopDefaultMode);
+    }
+    if(product) {
+        CFRelease(cfproduct);
+    }
+    CFRelease(cfkarabiner);
+}
+
+/*
+ * We'll register this callback to run whenever an IOHIDDevice
+ * (representing a keyboard) is connected to the OS
+ *
+ */
+void matched_callback(void *context, io_iterator_t iter) {
+    char *product = (char *)context;
+    open_matching_devices(product, iter);
+}
+
+/*
+ * We'll register this callback to run whenever an IOHIDDevice
+ * (representing a keyboard) is disconnected from the OS
+ *
+ */
+void terminated_callback(void *context, io_iterator_t iter) {
+    for(mach_port_t curr = IOIteratorNext(iter); curr; curr = IOIteratorNext(iter)) {
+        source_device.erase(curr);
+    }
+}
+
+/*
+ * This gets us some code reuse (see the send_key overload below)
+ */
+template<typename T>
+int send_key(T &keyboard, struct KeyEvent *e) {
+    if(e->type == 0) keyboard.keys.insert((uint16_t)e->keycode);
+    else if (e->type == 1) keyboard.keys.erase((uint16_t)e->keycode);
+    return pqrs::karabiner_virtual_hid_device_methods::post_keyboard_input_report(connect, keyboard);
+}
+
+/*
+ * Haskell calls this with a new key event to send back to the OS. It
+ * posts the information to the karabiner kernel extension (which
+ * represents a virtual keyboard).
+ */
+extern "C" int send_key(struct KeyEvent *e) {
+    pqrs::karabiner_virtual_hid_device::usage_page usage_page = pqrs::karabiner_virtual_hid_device::usage_page(e->keycode >> 16);
+    if(usage_page == pqrs::karabiner_virtual_hid_device::usage_page::keyboard_or_keypad)
+        return send_key(keyboard, e);
+    else if(usage_page == pqrs::karabiner_virtual_hid_device::usage_page::apple_vendor_top_case)
+        return send_key(top_case, e);
+    else if(usage_page == pqrs::karabiner_virtual_hid_device::usage_page::apple_vendor_keyboard)
+        return send_key(apple_keyboard, e);
+    else if(usage_page == pqrs::karabiner_virtual_hid_device::usage_page::consumer)
+        return send_key(consumer, e);
+    else
+        return 1;
+}
+
+/*
+ * Reads a new key event from the pipe, blocking until a new event is
+ * ready.
+ */
+extern "C" int wait_key(struct KeyEvent *e) {
+    return read(fd[0], e, sizeof(struct KeyEvent)) == sizeof(struct KeyEvent);
+}
+
+/*
+ * For each keyboard, registers an asynchronous callback to run when
+ * new input from the user is available from that keyboard. Then
+ * sleeps indefinitely, ready to received asynchronous callbacks.
+ */
+void monitor_kb(char *product) {
+    kern_return_t kr;
+    CFMutableDictionaryRef matching_dictionary = IOServiceMatching(kIOHIDDeviceKey);
+    if(!matching_dictionary) {
+        std::cerr << "IOServiceMatching error" << std::endl;
+        return;
+    }
+    UInt32 value;
+    CFNumberRef cfValue;
+    value = kHIDPage_GenericDesktop;
+    cfValue = CFNumberCreate( kCFAllocatorDefault, kCFNumberSInt32Type, &value );
+    CFDictionarySetValue(matching_dictionary, CFSTR(kIOHIDDeviceUsagePageKey), cfValue);
+    CFRelease(cfValue);
+    value = kHIDUsage_GD_Keyboard;
+    cfValue = CFNumberCreate( kCFAllocatorDefault, kCFNumberSInt32Type, &value );
+    CFDictionarySetValue(matching_dictionary,CFSTR(kIOHIDDeviceUsageKey),cfValue);
+    CFRelease(cfValue);
+    io_iterator_t iter = IO_OBJECT_NULL;
+    CFRetain(matching_dictionary);
+    kr = IOServiceGetMatchingServices(kIOMasterPortDefault,
+                                      matching_dictionary,
+                                      &iter);
+    if(kr != KERN_SUCCESS) {
+        std::cerr << "IOServiceGetMatchingServices error: " << std::hex << kr << std::endl;
+        return;
+    }
+    listener_loop = CFRunLoopGetCurrent();
+    open_matching_devices(product, iter);
+    IONotificationPortRef notification_port = IONotificationPortCreate(kIOMasterPortDefault);
+    CFRunLoopSourceRef notification_source = IONotificationPortGetRunLoopSource(notification_port);
+    CFRunLoopAddSource(listener_loop, notification_source, kCFRunLoopDefaultMode);
+    CFRetain(matching_dictionary);
+    kr = IOServiceAddMatchingNotification(notification_port,
+                                          kIOMatchedNotification,
+                                          matching_dictionary,
+                                          matched_callback,
+                                          product,
+                                          &iter);
+    if(kr != KERN_SUCCESS) {
+        std::cerr << "IOServiceAddMatchingNotification error: " << std::hex << kr << std::endl;
+        return;
+    }
+    for(mach_port_t curr = IOIteratorNext(iter); curr; curr = IOIteratorNext(iter)) {}
+    kr = IOServiceAddMatchingNotification(notification_port,
+                                          kIOTerminatedNotification,
+                                          matching_dictionary,
+                                          terminated_callback,
+                                          NULL,
+                                          &iter);
+    if(kr != KERN_SUCCESS) {
+        std::cerr << "IOServiceAddMatchingNotification error: " << std::hex << kr << std::endl;
+        return;
+    }
+    for(mach_port_t curr = IOIteratorNext(iter); curr; curr = IOIteratorNext(iter)) {}
+    CFRunLoopRun();
+    for(std::pair<const io_service_t,IOHIDDeviceRef> p: source_device) {
+        kr = IOHIDDeviceClose(p.second,kIOHIDOptionsTypeSeizeDevice);
+        if(kr != KERN_SUCCESS) {
+            std::cerr << "IOHIDDeviceClose error: " << std::hex << kr << std::endl;
+        }
+    }
+}
+
+/*
+ * Opens and seizes input from each keyboard device whose product name
+ * matches the parameter (if NULL is received, then it opens all
+ * keyboard devices). Spawns a thread to receive asynchronous input
+ * and opens a pipe for this thread to send key event data to the main
+ * thread.
+ *
+ * Loads a the karabiner kernel extension that will send key events
+ * back to the OS.
+ */
+extern "C" int grab_kb(char *product) {
+    // Source
+    if (pipe(fd) == -1) {
+        std::cerr << "pipe error: " << errno << std::endl;
+        return errno;
+    }
+    if(product) {
+        prod = (char *)malloc(strlen(product) + 1);
+        strcpy(prod, product);
+    }
+    thread = std::thread{monitor_kb, prod};
+    // Sink
+    kern_return_t kr;
+    connect = IO_OBJECT_NULL;
+    service = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceNameMatching(pqrs::karabiner_virtual_hid_device::get_virtual_hid_root_name()));
+    if (!service) {
+        std::cerr << "IOServiceGetMatchingService error" << std::endl;
+        return 1;
+    }
+    kr = IOServiceOpen(service, mach_task_self(), kIOHIDServerConnectType, &connect);
+    if (kr != KERN_SUCCESS) {
+        std::cerr << "IOServiceOpen error: " << std::hex << kr << std::endl;
+        return kr;
+    }
+    //std::this_thread::sleep_for(std::chrono::milliseconds(10000));
+    //setuid(501);
+    {
+        pqrs::karabiner_virtual_hid_device::properties::keyboard_initialization properties;
+        kr = pqrs::karabiner_virtual_hid_device_methods::initialize_virtual_hid_keyboard(connect, properties);
+        if (kr != KERN_SUCCESS) {
+            std::cerr << "initialize_virtual_hid_keyboard error: " << std::hex << kr << std::endl;
+            return 1;
+        }
+        while (true) {
+            bool ready;
+            kr = pqrs::karabiner_virtual_hid_device_methods::is_virtual_hid_keyboard_ready(connect, ready);
+            if (kr != KERN_SUCCESS) {
+                std::cerr << "is_virtual_hid_keyboard_ready error: " << std::hex << kr << std::endl;
+                return kr;
+            } else {
+                if (ready) {
+                    break;
+                }
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+    }
+    {
+        pqrs::karabiner_virtual_hid_device::properties::keyboard_initialization properties;
+        properties.country_code = 33;
+        kr = pqrs::karabiner_virtual_hid_device_methods::initialize_virtual_hid_keyboard(connect, properties);
+        if (kr != KERN_SUCCESS) {
+            std::cerr << "initialize_virtual_hid_keyboard error: " << std::hex << kr << std::endl;
+            return kr;
+        }
+    }
+    return 0;
+}
+
+/*
+ * Releases the resources needed to receive key events from and send
+ * key events to the OS.
+ */
+extern "C" int release_kb() {
+    int retval = 0;
+    kern_return_t kr;
+    // Source
+    if(thread.joinable()) {
+        CFRunLoopStop(listener_loop);
+        thread.join();
+    } else {
+        std::cerr << "no thread was running!" << std::endl;
+    }
+    if(prod) {
+        free(prod);
+    }
+    if (close(fd[0]) == -1) {
+        std::cerr << "close error: " << errno << std::endl;
+        retval = 1;
+    }
+    if (close(fd[1]) == -1) {
+        std::cerr << "close error: " << errno << std::endl;
+        retval = 1;
+    }
+    // Sink
+    kr = pqrs::karabiner_virtual_hid_device_methods::reset_virtual_hid_keyboard(connect);
+    if (kr != KERN_SUCCESS) {
+        std::cerr << "reset_virtual_hid_keyboard error: " << std::hex << kr << std::endl;
+        retval = 1;
+    }
+    if (connect) {
+        kr = IOServiceClose(connect);
+        if(kr != KERN_SUCCESS) {
+            std::cerr << "IOServiceClose error: " << std::hex << kr << std::endl;
+            retval = 1;
+        }
+    }
+    if (service) {
+        kr = IOObjectRelease(service);
+        if(kr != KERN_SUCCESS) {
+            std::cerr << "IOObjectRelease error: " << std::hex << kr << std::endl;
+            retval = 1;
+        }
+    }
+    return retval;
+}

--- a/c_src/mac/list-keyboards.c
+++ b/c_src/mac/list-keyboards.c
@@ -1,0 +1,36 @@
+#include <IOKit/hid/IOHIDLib.h>
+#include <IOKit/hidsystem/IOHIDShared.h>
+
+int main() {
+    CFMutableDictionaryRef matching_dictionary = IOServiceMatching(kIOHIDDeviceKey);
+    if(!matching_dictionary) {
+        fprintf(stderr,"IOServiceMatching failed");
+        return 1;
+    }
+    UInt32 value;
+    CFNumberRef cfValue;
+    value = kHIDPage_GenericDesktop;
+    cfValue = CFNumberCreate( kCFAllocatorDefault, kCFNumberSInt32Type, &value );
+    CFDictionarySetValue(matching_dictionary, CFSTR(kIOHIDDeviceUsagePageKey), cfValue);
+    CFRelease(cfValue);
+    value = kHIDUsage_GD_Keyboard;
+    cfValue = CFNumberCreate( kCFAllocatorDefault, kCFNumberSInt32Type, &value );
+    CFDictionarySetValue(matching_dictionary,CFSTR(kIOHIDDeviceUsageKey),cfValue);
+    CFRelease(cfValue);
+    io_iterator_t iter = IO_OBJECT_NULL;
+    kern_return_t r = IOServiceGetMatchingServices(kIOMasterPortDefault,
+                                                   matching_dictionary,
+                                                   &iter);
+    if(r != KERN_SUCCESS) {
+        fprintf(stderr,"IOServiceGetMatchingServices failed");
+        return r;
+    }
+    for(mach_port_t curr = IOIteratorNext(iter); curr; curr = IOIteratorNext(iter)) {
+        CFTypeRef str = IORegistryEntryCreateCFProperty(curr,
+                                                        CFSTR("Product"),
+                                                        kCFAllocatorDefault,
+                                                        kIOHIDOptionsTypeNone);
+        CFShow(str);
+    }
+    return 0;
+}

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -35,6 +35,30 @@ Under Windows the `defcfg` block is even simpler, you have no options.
 - `input`: `(low-level-hook)`
 - `output`: `(send-event-sink)`
 
+#### Mac
+Under Mac, the current valid values are:
+- `input`: `(iokit-name "optional product string")`
+- `output`: `(kext)`
+
+By default, kmonad will modify input from all keyboards. If a product
+string is provided, kmonad will modify input from all keyboards whose
+product string matches the given product string.
+
+To determine the product string of the connected keyboards, you can
+run:
+```shell
+cd c_src/mac
+make
+./list-keyboards
+```
+
+Note: Apple keyboards support a function-lock feature by default,
+where the function keys have special behaviors when held with
+<kbd>fn</kbd> (such as changing brightness or volume). KMonad seizes
+keyboard events before the function-lock feature is
+applied. Therefore, under KMonad, this feature will no longer take
+effect, but may be imitated in your KMonad configuration.
+
 ### `defsrc` block
 KMonad translates an input stream of key-events to an output stream of key
 events. The `defsrc` block exists as the specification of the input-layout. In

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -5,6 +5,7 @@ Jump to
   - [Using nix](installation.md#using-nix)
   - [Using stack](installation.md#using-stack)
   - [Windows environment](installation.md#windows-environment)
+  - [Mac](installation.md#mac)
 - [Binaries](installation.md#binaries)
 - [Packages](installation.md#packages)
   - [Void Linux](installation.md#void-linux)
@@ -57,6 +58,38 @@ installation](https://www.haskell.org/platform). I also needed to install
 [mingw](http://mingw.org) to provide `gcc`. With both the Haskell platform and
 `mingw` building `kmonad` under Windows10 should as simple as `stack build`.
 
+### Mac
+
+Mac support only for version 10.12 to 10.15. Support for Mac version
+11.0 is planned.
+
+Note: `kmonad` uses a [kernel
+extension](https://github.com/pqrs-org/Karabiner-VirtualHIDDevice)
+(kext) to post modified key events to the OS. This kext is tedious to
+build from source, and the OS won't load it unless you sign it with an
+"Apple Developer ID."  An easier way to install this kext is to
+install
+[Karabiner-Elements](https://github.com/pqrs-org/Karabiner-Elements),
+which uses the same kext.
+
+Compilation under Mac currently works with `stack`. Compilation under
+Mac via `nix` is not tested or planned. To compile on Mac, download
+the kmonad source:
+```shell
+git clone --recursive https://github.com/david-janssen/kmonad.git
+```
+
+Then, if you want to attempt building and signing the kext yourself,
+look to [the
+documentation](https://github.com/pqrs-org/Karabiner-VirtualHIDDevice)
+for instructions. Otherwise, make sure you have
+[Karabiner-Elements](https://github.com/pqrs-org/Karabiner-Elements)
+installed.
+
+Finally, build kmonad with `stack`:
+```shell
+stack build
+```
 
 ## Binaries
 

--- a/doc/syntax_guide.md
+++ b/doc/syntax_guide.md
@@ -74,6 +74,17 @@ simply:
 INPUT = LL_KEYBOARD_HOOK
 ```
 
+#### Mac
+Under Mac, KMonad installs a callback for each of the specified
+keyboards. Each callback triggers whenever new input is available
+from its associated keyboard.
+
+Note that capturing key events and stopping them in order to send
+modified events [requires root
+privilege](https://developer.apple.com/library/archive/technotes/tn2187/_index.html#//apple_ref/doc/uid/DTS10004224-CH1-DontLinkElementID_10).
+In the future, privilege separation may be implemented so that just a
+small part of KMonad requires root privilege to run.
+
 ### Output
 #### Linux
 We currently use the `uinput` subsystem to create a simulated keyboard over
@@ -123,6 +134,15 @@ simply:
 ```
 OUTPUT = SEND_EVENT_SINK
 ```
+
+#### Mac
+KMonad under Mac uses a [kernel
+extension](https://github.com/pqrs-org/Karabiner-VirtualHIDDevice)
+(kext) that acts as a virtual keyboard to simulate keyboard events.
+
+This kernel extension will become deprecated in Mac 11.0 (Big Sur),
+but its maintainer is working on a
+[replacement](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice).
 
 ## Aliases
 Since we use alignment to indicate button correspondence, it is very cumbersome

--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -1,4 +1,4 @@
-cabal-version: 1.12
+cabal-version: 2.2
 
 name:           kmonad
 version:        1.0
@@ -91,6 +91,24 @@ library
     build-depends:
       Win32
 
+  if os(darwin)
+    exposed-modules:
+      KMonad.Keyboard.IO.Mac.IOKitSource
+      KMonad.Keyboard.IO.Mac.KextSink
+      KMonad.Keyboard.IO.Mac.Types
+    cxx-sources:
+      c_src/mac/keyio_mac.cpp
+    cxx-options:
+      -std=c++14
+    include-dirs:
+      c_src/mac/Karabiner-VirtualHIDDevice/dist/include
+    extra-libraries:
+      c++
+    build-depends:
+      unix
+    frameworks:
+      CoreFoundation
+      IOKit
 
 executable kmonad
   ghc-options:

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -263,13 +263,15 @@ buttonP = (lexeme . choice . map try $
 itokenP :: Parser IToken
 itokenP = choice . map try $
   [ statement "device-file"    $ KDeviceSource <$> (T.unpack <$> textP)
-  , statement "low-level-hook" $ pure KLowLevelHookSource ]
+  , statement "low-level-hook" $ pure KLowLevelHookSource
+  , statement "iokit-name"     $ KIOKitSource <$> optional textP]
 
 -- | Parse an output token
 otokenP :: Parser OToken
 otokenP = choice . map try $
   [ statement "uinput-sink"     $ KUinputSink <$> lexeme textP <*> optional textP
-  , statement "send-event-sink" $ pure KSendEventSink ]
+  , statement "send-event-sink" $ pure KSendEventSink
+  , statement "kext"            $ pure KKextSink]
 
 -- | Parse the DefCfg token
 defcfgP :: Parser DefSettings

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -140,12 +140,14 @@ data DefLayer = DefLayer
 data IToken
   = KDeviceSource FilePath
   | KLowLevelHookSource
+  | KIOKitSource (Maybe Text)
   deriving Show
 
 -- | All different output-tokens KMonad can take
 data OToken
   = KUinputSink Text (Maybe Text)
   | KSendEventSink
+  | KKextSink
   deriving Show
 
 -- | All possible single settings

--- a/src/KMonad/Keyboard/IO/Mac/IOKitSource.hs
+++ b/src/KMonad/Keyboard/IO/Mac/IOKitSource.hs
@@ -1,0 +1,80 @@
+module KMonad.Keyboard.IO.Mac.IOKitSource
+  ( iokitSource
+  )
+where
+
+import KMonad.Prelude
+
+import Foreign.Marshal hiding (void)
+import Foreign.Ptr
+import Foreign.Storable
+import Foreign.C.String
+
+import KMonad.Keyboard
+import KMonad.Keyboard.IO
+import KMonad.Keyboard.IO.Mac.Types
+
+--------------------------------------------------------------------------------
+
+-- | Use the mac c-api to `grab` a keyboard
+foreign import ccall "grab_kb"
+  grab_kb :: CString -> IO Word8
+
+-- | Release the keyboard hook
+foreign import ccall "release_kb"
+  release_kb :: IO Word8
+
+-- | Pass a pointer to a buffer to wait_key, when it returns the buffer can be
+-- read for the next key event.
+foreign import ccall "wait_key"
+  wait_key :: Ptr MacKeyEvent -> IO Word8
+
+
+data EvBuf = EvBuf
+  { _buffer :: !(Ptr MacKeyEvent)
+  }
+makeLenses ''EvBuf
+
+-- | Return a KeySource using the Mac IOKit approach
+iokitSource :: HasLogFunc e
+  => (Maybe String)
+  -> RIO e (Acquire KeySource)
+iokitSource name = mkKeySource (iokitOpen name) iokitClose iokitRead
+
+
+--------------------------------------------------------------------------------
+
+-- | Ask IOKit to open keyboards matching the specified name
+iokitOpen :: HasLogFunc e
+  => (Maybe String)
+  -> RIO e EvBuf
+iokitOpen m = do
+  logInfo "Opening IOKit devices"
+  liftIO $ do
+    str <- newCString (case m of
+                       Nothing -> ""
+                       Just s -> s)
+    _ <- grab_kb (case m of
+                    Nothing -> nullPtr
+                    Just _ -> str)
+    free str
+    buf <- mallocBytes $ sizeOf (undefined :: MacKeyEvent)
+    pure $ EvBuf buf
+
+-- | Ask Mac to close the queue
+iokitClose :: HasLogFunc e => EvBuf -> RIO e ()
+iokitClose b = do
+  logInfo "Closing IOKit devices"
+  liftIO $ do
+    _ <- release_kb
+    free $ b^.buffer
+
+-- | Get a new 'KeyEvent' from Mac
+--
+-- NOTE: This can throw an error if the event fails to convert.
+iokitRead :: HasLogFunc e => EvBuf -> RIO e KeyEvent
+iokitRead b = do
+  we <- liftIO $ do
+    _ <- wait_key $ b^.buffer
+    peek $ b^.buffer
+  either throwIO pure $ fromMacKeyEvent we

--- a/src/KMonad/Keyboard/IO/Mac/KextSink.hs
+++ b/src/KMonad/Keyboard/IO/Mac/KextSink.hs
@@ -1,0 +1,46 @@
+module KMonad.Keyboard.IO.Mac.KextSink
+  ( kextSink
+  )
+where
+
+import KMonad.Prelude
+
+import Foreign.Ptr
+import Foreign.Marshal
+import Foreign.Storable
+
+import KMonad.Keyboard
+import KMonad.Keyboard.IO
+import KMonad.Keyboard.IO.Mac.Types
+
+foreign import ccall "send_key"
+  send_key :: Ptr MacKeyEvent -> IO ()
+
+data EvBuf = EvBuf
+  { _buffer :: Ptr MacKeyEvent -- ^ The pointer we write events to
+  }
+makeClassy ''EvBuf
+
+kextSink :: HasLogFunc e => RIO e (Acquire KeySink)
+kextSink = mkKeySink skOpen skClose skSend
+
+-- | Create the 'EvBuf' environment
+skOpen :: HasLogFunc e => RIO e EvBuf
+skOpen = do
+  logInfo "Initializing Mac key sink"
+  liftIO $ EvBuf <$> mallocBytes (sizeOf (undefined :: MacKeyEvent))
+
+-- | Close the 'EvBuf' environment
+skClose :: HasLogFunc e => EvBuf -> RIO e ()
+skClose sk = do
+  logInfo "Closing Mac key sink"
+  liftIO . free $ sk^.buffer
+
+-- | Write an event to the pointer and prompt windows to inject it
+--
+-- NOTE: This can throw an error if event-conversion fails.
+skSend :: HasLogFunc e => EvBuf -> KeyEvent -> RIO e ()
+skSend sk e = either throwIO go $ toMacKeyEvent e
+  where go e' = liftIO $ do
+          poke (sk^.buffer) e'
+          send_key $ sk^.buffer

--- a/src/KMonad/Keyboard/IO/Mac/Types.hs
+++ b/src/KMonad/Keyboard/IO/Mac/Types.hs
@@ -1,0 +1,306 @@
+module KMonad.Keyboard.IO.Mac.Types
+  ( MacError(..)
+  , MacKeyEvent
+  , mkMacKeyEvent
+  , toMacKeyEvent
+  , fromMacKeyEvent
+  )
+
+where
+
+import KMonad.Prelude
+
+import Foreign.Storable
+import KMonad.Keyboard
+
+import qualified RIO.HashMap as M
+
+
+----------------------------------------------------------------------------
+-- $err
+
+-- | Everything that can go wrong with Mac Key-IO
+data MacError
+  = NoMacKeycodeTo   Keycode    -- ^ Error translating to 'MacKeycode'
+  | NoMacKeycodeFrom MacKeycode -- ^ Error translating from 'MacKeycode'
+
+instance Exception MacError
+instance Show MacError where
+  show e = case e of
+    NoMacKeycodeTo   c -> "Cannot translate to mac keycode: "   <> show c
+    NoMacKeycodeFrom i -> "Cannot translate from mac keycode: " <> show i
+
+--------------------------------------------------------------------------------
+-- $typ
+
+type MacSwitch  = Word8  -- ^ Type alias for the switch value
+type MacKeycode = Word32 -- ^ Type alias for the Mac keycode
+
+-- | 'MacKeyEvent' is the C-representation of a a 'KeyEvent' for our Mac API.
+--
+-- It contains a 'Word8' signifying whether the event was a Press (0)
+-- or Release (1), and a 'Word32' (uint32_t) signifying the Mac
+-- keycode (the upper 16 bits represent the IOKit usage page, and the
+-- lower 16 bits represent the IOKit usage).
+--
+-- NOTE: Mac and Linux keycodes do not line up. Internally we use Linux
+-- Keycodes for everything, we translate at the KeyIO stage (here).
+newtype MacKeyEvent = MacKeyEvent (MacSwitch, MacKeycode)
+  deriving (Eq, Ord, Show)
+
+-- | This lets us send 'MacKeyEvent's between Haskell and C.
+instance Storable MacKeyEvent where
+  alignment _ = 4 -- lowest common denominator of: 1 4
+  sizeOf    _ = 8 -- (1 + 3-padding) + 4
+  peek ptr = do
+    s <- peekByteOff ptr 0
+    c <- peekByteOff ptr 4
+    return $ MacKeyEvent (s, c)
+  poke ptr (MacKeyEvent (s, c)) = do
+    pokeByteOff ptr 0 s
+    pokeByteOff ptr 4 c
+
+mkMacKeyEvent :: MacSwitch -> MacKeycode -> MacKeyEvent
+mkMacKeyEvent s e = MacKeyEvent (s, e)
+
+--------------------------------------------------------------------------------
+-- $conv
+
+-- | Convert between 'MacSwitch' and 'Switch' representations.
+--
+-- NOTE: Although 'MacSwitch' could theoretically be something besides 0 or 1,
+-- practically it can't, because those are the only values the API generates,
+-- guaranteed.
+_MacSwitch :: Iso' MacSwitch Switch
+_MacSwitch = iso to' from'
+  where
+    to' w   = if w == 0 then Press else Release
+    from' s = if s == Press then 0 else 1
+
+-- | Lookup the corresponding 'Keycode' for this 'MacKeycode'
+fromMacKeycode :: MacKeycode -> Maybe Keycode
+fromMacKeycode = flip M.lookup kcMap
+
+-- | Lookup the correspondig 'MacKeycode' for this 'Keycode'
+toMacKeycode :: Keycode -> Maybe MacKeycode
+toMacKeycode = flip M.lookup revMap
+  where revMap = M.fromList $ (M.toList kcMap) ^.. folded . swapped
+
+-- | Convert a 'KeyEvent' to a 'MacKeyEvent'
+--
+-- NOTE: Mac keycodes are different, and I am not confident I have full
+-- coverage, therefore this conversion is not total. We are going to leave this
+-- error-handling in until we are sure this is covered well. Once it lines up
+-- perfectly, this is essentially an Iso.
+toMacKeyEvent :: KeyEvent -> Either MacError MacKeyEvent
+toMacKeyEvent e = case toMacKeycode $ e^.keycode of
+  Just c  -> Right $ MacKeyEvent (e^.switch.from _MacSwitch, c)
+  Nothing -> Left . NoMacKeycodeTo $ e^.keycode
+
+-- | Convert a 'MacKeyEvent' to a 'KeyEvent'
+--
+-- NOTE: Same limitations as 'toMacKeyEvent' apply
+fromMacKeyEvent :: MacKeyEvent -> Either MacError KeyEvent
+fromMacKeyEvent (MacKeyEvent (s, c)) = case fromMacKeycode c of
+  Just c' -> Right $ mkKeyEvent (s^._MacSwitch) c'
+  Nothing -> Left . NoMacKeycodeFrom $ c
+
+
+--------------------------------------------------------------------------------
+-- $kc
+
+-- | Mac does not use the same keycodes as Linux, so we need to translate.
+--
+-- See https://opensource.apple.com/source/IOHIDFamily/IOHIDFamily-315.7.16/IOHIDFamily/IOHIDUsageTables.h
+-- See https://opensource.apple.com/source/IOHIDFamily/IOHIDFamily-700/IOHIDFamily/AppleHIDUsageTables.h.auto.html
+kcMap :: M.HashMap MacKeycode Keycode
+kcMap = M.fromList $
+  [ (0x00070000, KeyError) -- There's no documentation on this error code, but
+                           -- I've seen it sent when the rollover is exceeded on
+                           -- my macbook internal keyboard
+  , (0x00070001, KeyError) -- kHIDUsage_KeyErrorRollOver
+  , (0x00070002, KeyError) -- kHIDUsage_KeyPOSTFail
+  , (0x00070003, KeyError) -- kHIDUsage_Undefined
+  , (0x00070004, KeyA)
+  , (0x00070005, KeyB)
+  , (0x00070006, KeyC)
+  , (0x00070007, KeyD)
+  , (0x00070008, KeyE)
+  , (0x00070009, KeyF)
+  , (0x0007000A, KeyG)
+  , (0x0007000B, KeyH)
+  , (0x0007000C, KeyI)
+  , (0x0007000D, KeyJ)
+  , (0x0007000E, KeyK)
+  , (0x0007000F, KeyL)
+  , (0x00070010, KeyM)
+  , (0x00070011, KeyN)
+  , (0x00070012, KeyO)
+  , (0x00070013, KeyP)
+  , (0x00070014, KeyQ)
+  , (0x00070015, KeyR)
+  , (0x00070016, KeyS)
+  , (0x00070017, KeyT)
+  , (0x00070018, KeyU)
+  , (0x00070019, KeyV)
+  , (0x0007001A, KeyW)
+  , (0x0007001B, KeyX)
+  , (0x0007001C, KeyY)
+  , (0x0007001D, KeyZ)
+  , (0x0007001E, Key1)
+  , (0x0007001F, Key2)
+  , (0x00070020, Key3)
+  , (0x00070021, Key4)
+  , (0x00070022, Key5)
+  , (0x00070023, Key6)
+  , (0x00070024, Key7)
+  , (0x00070025, Key8)
+  , (0x00070026, Key9)
+  , (0x00070027, Key0)
+  , (0x00070028, KeyEnter)
+  , (0x00070029, KeyEsc)
+  , (0x0007002A, KeyBackspace)
+  , (0x0007002B, KeyTab)
+  , (0x0007002C, KeySpace)
+  , (0x0007002D, KeyMinus)
+  , (0x0007002E, KeyEqual)
+  , (0x0007002F, KeyLeftBrace)
+  , (0x00070030, KeyRightBrace)
+  , (0x00070031, KeyBackslash)
+  -- , (0x00070032, KeyNonUSPound)
+  , (0x00070033, KeySemicolon)
+  , (0x00070034, KeyApostrophe)
+  , (0x00070035, KeyGrave)
+  , (0x00070036, KeyComma)
+  , (0x00070037, KeyDot)
+  , (0x00070038, KeySlash)
+  , (0x00070039, KeyCapsLock)
+  , (0x0007003A, KeyF1)
+  , (0x0007003B, KeyF2)
+  , (0x0007003C, KeyF3)
+  , (0x0007003D, KeyF4)
+  , (0x0007003E, KeyF5)
+  , (0x0007003F, KeyF6)
+  , (0x00070040, KeyF7)
+  , (0x00070041, KeyF8)
+  , (0x00070042, KeyF9)
+  , (0x00070043, KeyF10)
+  , (0x00070044, KeyF11)
+  , (0x00070045, KeyF12)
+  , (0x00070046, KeyPrint)
+  , (0x00070047, KeyScrollLock)
+  , (0x00070048, KeyPause)
+  , (0x00070049, KeyInsert)
+  , (0x0007004A, KeyHome)
+  , (0x0007004B, KeyPageUp)
+  , (0x0007004C, KeyDelete)
+  , (0x0007004D, KeyEnd)
+  , (0x0007004E, KeyPageDown)
+  , (0x0007004F, KeyRight)
+  , (0x00070050, KeyLeft)
+  , (0x00070051, KeyDown)
+  , (0x00070052, KeyUp)
+  , (0x00070053, KeyNumLock)
+  , (0x00070054, KeyKpSlash)
+  , (0x00070055, KeyKpAsterisk)
+  , (0x00070056, KeyKpMinus)
+  , (0x00070057, KeyKpPlus)
+  , (0x00070058, KeyKpenter)
+  , (0x00070059, KeyKp1)
+  , (0x0007005A, KeyKp2)
+  , (0x0007005B, KeyKp3)
+  , (0x0007005C, KeyKp4)
+  , (0x0007005D, KeyKp5)
+  , (0x0007005E, KeyKp6)
+  , (0x0007005F, KeyKp7)
+  , (0x00070060, KeyKp8)
+  , (0x00070061, KeyKp9)
+  , (0x00070062, KeyKp0)
+  , (0x00070063, KeyKpDot)
+  -- , (0x00070064, KeyNonUSBackslash)
+  -- , (0x00070065, KeyApplication)
+  , (0x00070066, KeyPower)
+  , (0x00070067, KeyKpEqual)
+  , (0x00070068, KeyF13)
+  , (0x00070069, KeyF14)
+  , (0x0007006A, KeyF15)
+  , (0x0007006B, KeyF16)
+  , (0x0007006C, KeyF17)
+  , (0x0007006D, KeyF18)
+  , (0x0007006E, KeyF19)
+  , (0x0007006F, KeyF20)
+  , (0x00070070, KeyF21)
+  , (0x00070071, KeyF22)
+  , (0x00070072, KeyF23)
+  , (0x00070073, KeyF24)
+  -- , (0x00070074, KeyExecute)
+  , (0x00070075, KeyHelp)
+  , (0x00070076, KeyMenu)
+  -- , (0x00070077, KeySelect)
+  , (0x00070078, KeyStop)
+  , (0x00070079, KeyAgain)
+  , (0x0007007A, KeyUndo)
+  , (0x0007007B, KeyCut)
+  , (0x0007007C, KeyCopy)
+  , (0x0007007D, KeyPaste)
+  , (0x0007007E, KeyFind)
+  , (0x0007007F, KeyMute)
+  , (0x00070080, KeyVolumeUp)
+  , (0x00070081, KeyVolumeDown)
+  -- , (0x00070082, KeyLockingCapsLock)
+  -- , (0x00070083, KeyLockingNumLock)
+  -- , (0x00070084, KeyLockingScrollLock)
+  , (0x00070085, KeyKpComma)
+  -- , (0x00070086, KeyKpEqualSignAS400)
+  -- , (0x00070087, KeyInternational1)
+  -- , (0x00070088, KeyInternational2)
+  -- , (0x00070089, KeyInternational3)
+  -- , (0x0007008A, KeyInternational4)
+  -- , (0x0007008B, KeyInternational5)
+  -- , (0x0007008C, KeyInternational6)
+  -- , (0x0007008D, KeyInternational7)
+  -- , (0x0007008E, KeyInternational8)
+  -- , (0x0007008F, KeyInternational9)
+  -- , (0x00070090, KeyLANG1)
+  -- , (0x00070091, KeyLANG2)
+  -- , (0x00070092, KeyLANG3)
+  -- , (0x00070093, KeyLANG4)
+  -- , (0x00070094, KeyLANG5)
+  -- , (0x00070095, KeyLANG6)
+  -- , (0x00070096, KeyLANG7)
+  -- , (0x00070097, KeyLANG8)
+  -- , (0x00070098, KeyLANG9)
+  -- , (0x00070099, KeyAlternateErase)
+  -- , (0x0007009A, KeySysReqOrAttention)
+  , (0x0007009B, KeyCancel)
+  -- , (0x0007009C, KeyClear)
+  -- , (0x0007009D, KeyPrior)
+  -- , (0x0007009E, KeyReturn)
+  -- , (0x0007009F, KeySeparator)
+  -- , (0x000700A0, KeyOut)
+  -- , (0x000700A1, KeyOper)
+  -- , (0x000700A2, KeyClearOrAgain)
+  -- , (0x000700A3, KeyCrSelOrProps)
+  -- , (0x000700A4, KeyExSel)
+  -- /* 0x000700A5-0x000700DF Reserved */
+  , (0x000700E0, KeyLeftCtrl)
+  , (0x000700E1, KeyLeftShift)
+  , (0x000700E2, KeyLeftAlt)
+  , (0x000700E3, KeyLeftMeta)
+  , (0x000700E4, KeyRightCtrl)
+  , (0x000700E5, KeyRightShift)
+  , (0x000700E6, KeyRightAlt)
+  , (0x000700E7, KeyRightMeta)
+  -- /* 0x000700E8-0x0007FFFF Reserved */
+  , (0x0007FFFF, KeyReserved)
+  , (0x000C00B5, KeyNextSong)
+  , (0x000C00B6, KeyPreviousSong)
+  , (0x000C00CD, KeyPlayPause)
+  , (0x00FF0003, KeyFn)
+  , (0x00FF0004, KeyBrightnessUp)
+  , (0x00FF0005, KeyBrightnessDown)
+  , (0x00FF0008, KeyBacklightUp)
+  , (0x00FF0009, KeyBacklightDown)
+  , (0xFF010004, KeyLaunchpad)
+  , (0xFF010010, KeyMissionCtrl)
+  ]

--- a/src/KMonad/Keyboard/Keycode.hs
+++ b/src/KMonad/Keyboard/Keycode.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass, CPP #-}
 {-|
 Module      : KMonad.Keyboard.Keycode
 Description : Description of all possible keycodes.
@@ -301,6 +301,14 @@ data Keycode
   | Missing253
   | Missing254
   | Missing255
+#ifdef darwin_HOST_OS
+  | KeyFn
+  | KeyLaunchpad
+  | KeyMissionCtrl
+  | KeyBacklightDown
+  | KeyBacklightUp
+  | KeyError
+#endif
   deriving (Eq, Show, Bounded, Enum, Ord, Generic, Hashable)
 
 
@@ -387,4 +395,10 @@ aliases = Q.mkMultiMap
   , (KeyComma,          ["comm", ","])
   , (KeyDot,            ["."])
   , (KeySlash,          ["/"])
+#ifdef darwin_HOST_OS
+  , (KeyLaunchpad,      ["lp"])
+  , (KeyMissionCtrl,    ["mctl"])
+  , (KeyBacklightDown,  ["bldn"])
+  , (KeyBacklightUp,    ["blup"])
+#endif
   ]


### PR DESCRIPTION
Some notes on the changes:

- Mac support depends on a [kernel extension](https://github.com/pqrs-org/Karabiner-VirtualHIDDevice) which I added as a submodule
- I increased the Cabal version from 1.12 to 2.2, which is required to build C++ sources
- Requires root privilege to run on Mac. Maybe at some point I'll separate kmonad into two processes; one privileged that runs just a subset of the C++ code to listen for keyboard input, and one unprivileged that runs the bulk of kmonad.
- In doc/syntax_guide.md, I wasn't sure how to add the `INPUT` and `OUTPUT` syntax for Mac, so I didn't
- I added some Mac-specific keycodes to src/KMonad/Keyboard/Keycode.hs (but I put them inside a preprocessing directive to build only on Mac)
- I wrote a function called iokitOpen in src/KMonad/Keyboard/IO/Mac/IOKitSource.hs that allocates a C string even in the case when it's not needed. Is there a cleaner way to write this function that avoids the unnecessary allocation and release?

Thanks!