### PR TITLE
Add layer-add and layer-rem buttons

### DIFF
--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -319,6 +319,12 @@ joinButton ns als =
     KLayerSwitch t -> if t `elem` ns
       then ret $ layerSwitch t
       else throwError $ MissingLayer t
+    KLayerAdd t -> if t `elem` ns
+      then ret $ layerAdd t
+      else throwError $ MissingLayer t
+    KLayerRem t -> if t `elem` ns
+      then ret $ layerRem t
+      else throwError $ MissingLayer t
     KLayerDelay s t -> if t `elem` ns
       then ret $ layerDelay (fi s) t
       else throwError $ MissingLayer t

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -241,6 +241,8 @@ buttonP = (lexeme . choice . map try $
   , statement "tap-next"       $ KTapNext     <$> buttonP     <*> buttonP
   , statement "layer-toggle"   $ KLayerToggle <$> word
   , statement "layer-switch"   $ KLayerSwitch <$> word
+  , statement "layer-add"      $ KLayerAdd    <$> word
+  , statement "layer-rem"      $ KLayerRem    <$> word
   , statement "layer-delay"    $ KLayerDelay  <$> lexeme numP <*> word
   , statement "layer-next"     $ KLayerNext   <$> word
   , statement "around-next"    $ KAroundNext  <$> buttonP

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -79,6 +79,8 @@ data DefButton
   | KEmit Keycode                          -- ^ Emit a keycode
   | KLayerToggle Text                      -- ^ Toggle to a layer when held
   | KLayerSwitch Text                      -- ^ Switch base-layer when pressed
+  | KLayerAdd Text                         -- ^ Add a layer when pressed
+  | KLayerRem Text                         -- ^ Remove top instance of a layer when pressed
   | KTapNext DefButton DefButton           -- ^ Do 2 things based on behavior
   | KTapHold Int DefButton DefButton       -- ^ Do 2 things based on behavior and delay
   | KTapHoldNext Int DefButton DefButton   -- ^ Mixture between KTapNext and KTapHold

--- a/src/KMonad/Button.hs
+++ b/src/KMonad/Button.hs
@@ -29,6 +29,8 @@ module KMonad.Button
   , modded
   , layerToggle
   , layerSwitch
+  , layerAdd
+  , layerRem
   , pass
 
   -- * Button combinators
@@ -132,6 +134,14 @@ layerToggle t = mkButton
 -- | Create a button that switches the base-layer on a press
 layerSwitch :: LayerTag -> Button
 layerSwitch t = onPress (layerOp $ SetBaseLayer t)
+
+-- | Create a button that adds a layer on a press
+layerAdd :: LayerTag -> Button
+layerAdd t = onPress (layerOp $ PushLayer t)
+
+-- | Create a button that removes the top instance of a layer on a press
+layerRem :: LayerTag -> Button
+layerRem t = onPress (layerOp $ PopLayer t)
 
 -- | Create a button that does nothing (but captures the input)
 pass :: Button


### PR DESCRIPTION
This was in the documentation for the original version but I couldn't find these buttons in the refactor branch.