### PR TITLE
Activate fallthrough in testing.kbd

### DIFF
--- a/keymap/user/david-janssen/testing.kbd
+++ b/keymap/user/david-janssen/testing.kbd
@@ -4,6 +4,7 @@
   input  (device-file "/dev/input/by-id/usb-04d9_daskeyboard-event-kbd")
   output (uinput-sink "KMonad: Testing keyboard"
             "/run/current-system/sw/bin/sleep 1 && /run/current-system/sw/bin/setxkbmap -option compose:ralt")
+  fallthrough true
   )
 
 (defalias


### PR DESCRIPTION
I tested `testing.kbd` and got totally trapped. I couldn't stop KMonad because neither my mouse nor the control keys worked anymore. I could not even start a new terminal and execute `pkill kmonad`. So I had to poweroff my laptop the hard way.

I'm activating `fallthrough` for saving the next one trying out `testing.kbd`.