### PR TITLE
Added a keymap template for ISO keyboards

### DIFF
--- a/keymap/template/iso_60.kbd
+++ b/keymap/template/iso_60.kbd
@@ -1,0 +1,27 @@
+#| --------------------------------------------------------------------------
+
+                          KMonad: ISO 60% template
+
+  This file contains the `defsrc` configuration for a standard ISO 60%
+  keyboard. Modelled on a standard European keyboard 100% with the numpad, function
+  keys, arrows, and home-cluster removed. Copy out the 'defsrc' layer to start
+  your own keyboard configuration. Copy out the `deflayer` template to easily
+  start a new layer with matching `transparent` buttons.
+
+(deflayer name
+  _     _    _    _    _    _    _    _    _    _    _    _    _    _
+  _     _    _    _    _    _    _    _    _    _    _    _    _    _
+  _     _    _    _    _    _    _    _    _    _    _    _    _
+  _     _    _    _    _    _    _    _    _    _    _    _    _
+  _     _    _              _              _    _    _    _
+)
+
+  -------------------------------------------------------------------------- |#
+
+(defsrc
+  grv   1    2    3    4    5    6    7    8    9    0    -    =    bspc
+  tab   q    w    e    r    t    y    u    i    o    p    [    ]    ret
+  caps  a    s    d    f    g    h    j    k    l    ;    '    \
+  lsft iso   z    x    c    v    b    n    m    ,    .    /    rsft
+  lctl lmet lalt           spc            ralt rmet cmp  rctl
+)

--- a/src/KMonad/Keyboard/Keycode.hs
+++ b/src/KMonad/Keyboard/Keycode.hs
@@ -403,6 +403,7 @@ aliases = Q.mkMultiMap
   , (KeyKpMinus,        ["kp-"])
   , (KeyKpDot,          ["kp."])
   , (KeySysRq,          ["ssrq", "sys"])
+  , (KeyIso,            ["iso"])
 #ifdef darwin_HOST_OS
   , (KeyLaunchpad,      ["lp"])
   , (KeyMissionCtrl,    ["mctl"])


### PR DESCRIPTION
An alias "iso" for `KeyIso` has also been added.

I wasn't quite sure how to call the new keymap template file. At first, I named it `us_iso_60.kbd` in the same fashion as the preexisting `us_ansi_60.kbd` but then I thought that "US" and "ISO" in the same sentence sounds wrong. They don't care about the International Organization for Standardization in the United States. Another contestant was `uk_iso_60.kbd` but the keymap does not match the UK layout as it features the backslash on the ISO key. So I ended up with just `iso_60.kbd`

I've compiled my changes into a new executable and tested my keymap containing `iso` and it works fine.