### PR TITLE
kbd-mode for Emacs

### DIFF
--- a/elisp/kbd-mode.el
+++ b/elisp/kbd-mode.el
@@ -1,0 +1,131 @@
+;;; kbd-mode.el --- Syntax colouring for kmonad's .kbd files. -*- lexical-binding: t; -*-
+
+;; Copyright © 2020, slotThe
+;; License: GPL 3 or any later version
+
+;;; Commentary:
+
+;; TODO
+
+;;; Code:
+
+(defvar kbd-mode-kexpr
+  '("defcfg" "defsrc" "defalias")
+  "A K-Expression")
+
+(defvar kbd-mode-function-one
+  '("deflayer")
+  "Tokens that are treated as functions with one argument")
+
+(defface kbd-mode-kexpr-face
+  '((t :inherit font-lock-keyword-face))
+  "Face for a K-Expression")
+
+(defvar kbd-mode-token
+  '(;; input tokens
+    "uinput-sink" "send-event-sink" "kext"
+    ;; output tokens
+    "device-file" "low-level-hook" "iokit-name")
+  "Input and output tokens")
+
+(defface kbd-mode-token-face
+  '((t :inherit font-lock-function-name-face))
+  "Face for input and output tokens")
+
+(defvar kbd-mode-defcfg-options
+  '("input" "output" "cmp-seq" "init" "fallthrough" "allow-cmd")
+  "Options to give to `defcfg'")
+
+(defface kbd-mode-defcfg-option-face
+  '((t :inherit font-lock-builtin-face))
+  "Face for options one may give to `defcfg'")
+
+(defcustom kbd-mode-button-modifiers
+  '("around" "multi-tap" "tap-hold" "tap-hold-next" "tap-next-release"
+    "tap-hold-next-release" "tap-next" "layer-toggle" "layer-switch"
+    "layer-add" "layer-rem" "layer-delay" "layer-next" "around-next"
+    "tap-macro" "cmd-button")
+  "Button modifiers")
+
+(defface kbd-mode-button-modifier-face
+  '((t :inherit font-lock-function-name-face))
+  "Face for all the button modifiers")
+
+(defface kbd-mode-variable-name-face
+  '((t :inherit font-lock-variable-name-face))
+  "Face for a variables, i.e. layer names, macros in layers,...")
+
+(defcustom kbd-mode-show-macros t
+  "Whether to syntax highlight macros inside layout definitions.
+Default: t"
+  :type 'boolean)
+
+(defvar kbd-mode--comments-table
+  (let ((comments-table (make-syntax-table)))
+    (modify-syntax-entry ?\; ". 12b" comments-table)
+    (modify-syntax-entry ?\n "> b"   comments-table)
+    (modify-syntax-entry ?\# ". 14"  comments-table)
+    (modify-syntax-entry ?\| ". 23"  comments-table)
+    comments-table)
+  "Use ;; for regular comments and #| |# for line comments")
+
+(defvar kbd-mode--font-lock-keywords
+  (let ((kexpr-regexp            (regexp-opt kbd-mode-kexpr            'words))
+        (token-regexp            (regexp-opt kbd-mode-token            'words))
+        (defcfg-options-regexp   (regexp-opt kbd-mode-defcfg-options   'words))
+        (button-modifiers-regexp (regexp-opt kbd-mode-button-modifiers 'words))
+        (function-one-regexp     (concat "\\(?:\\("
+                                         (regexp-opt kbd-mode-function-one)
+                                         "\\)\\([[:space:]]+[[:word:]]+\\)\\)")))
+
+    `((,token-regexp            (1 'kbd-mode-token-face          ))
+      (,kexpr-regexp            (1 'kbd-mode-kexpr-face          ))
+      (,button-modifiers-regexp (1 'kbd-mode-button-modifier-face))
+      (,defcfg-options-regexp   (1 'kbd-mode-defcfg-option-face  ))
+      (,function-one-regexp
+       (1 'kbd-mode-kexpr-face        )
+       (2 'kbd-mode-variable-name-face))))
+  "Keywords to be syntax coloured")
+
+(define-derived-mode kbd-mode lisp-mode "kbd"
+  "Major mode for editing .kbd files"
+  (font-lock-add-keywords 'kbd-mode kbd-mode--font-lock-keywords)
+  (set-syntax-table kbd-mode--comments-table)
+
+  ;; TODO: There *has* to be a better way of doing this
+  (let ((macro-regexp '(("\\(:?\\(@[^[:space:]]+\\)\\)"
+                         (1 'kbd-mode-variable-name-face)))))
+    (if kbd-mode-show-macros
+        (font-lock-add-keywords 'kbd-mode macro-regexp)
+      (font-lock-remove-keywords 'kbd-mode macro-regexp)))
+
+  (setq syntax-propertize-function 'kbd--fix-quotes)
+  (syntax-propertize (point-max))
+
+  (font-lock-flush))
+
+(defun kbd--bracket-hack ()
+  (modify-syntax-entry ?\[ ".")
+  (modify-syntax-entry ?\] "."))
+(add-hook 'kbd-mode-hook #'kbd--bracket-hack)
+
+;; (add-hook 'kbd-mode-hook #'kbd--string-hack)
+;; (defun kbd--string-hack ()
+;;   (modify-syntax-entry ?\" "."))
+
+(defun kbd--fix-quotes (start end)
+  (when (eq major-mode 'kbd-mode)
+    (save-excursion
+      (goto-char start)
+      (while (re-search-forward "\"\\|\"" end t)
+        (when (save-excursion
+                (re-search-backward
+                 "\\(^\\S(*\\s(\\)\\(device-file\\)\\([[:space:]]\"[^\"]+\"\\)\\s)"
+                 nil
+                 t))
+          (put-text-property (point)
+                             (1- (point))
+                             'syntax-table (string-to-syntax ".")))))))
+
+(provide 'kbd-mode)
+;;; kbd-mode.el ends here

--- a/elisp/kbd-mode.el
+++ b/elisp/kbd-mode.el
@@ -2,6 +2,10 @@
 
 ;; Copyright 2020  slotThe
 
+;; Author: slotThe <soliditsallgood@mailbox.org>
+;; URL: TBD
+;; Version: 0.0.1
+
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation; either version 3, or (at your option)
@@ -113,17 +117,25 @@ Default: t"
   '((t :inherit font-lock-string-face))
   "Face for strings")
 
-;;; (Internal) Vars
+;;; Vars
 
-(defvar kbd-mode--comments-table nil
+(defvar kbd-mode-syntax-table nil
   "Use ;; for regular comments and #| |# for line comments")
-(setq kbd-mode--comments-table
-  (let ((comments-table (make-syntax-table)))
-    (modify-syntax-entry ?\; ". 12b" comments-table)
-    (modify-syntax-entry ?\n "> b"   comments-table)
-    (modify-syntax-entry ?\# ". 14"  comments-table)
-    (modify-syntax-entry ?\| ". 23"  comments-table)
-    comments-table))
+(setq kbd-mode-syntax-table
+  (let ((table (make-syntax-table)))
+    ;; Comments.
+    (modify-syntax-entry ?\; ". 12b" table)
+    (modify-syntax-entry ?\n "> b"   table)
+    (modify-syntax-entry ?\# ". 14"  table)
+    (modify-syntax-entry ?\| ". 23"  table)
+
+    ;; We don't need to highlight brackets, as they're only used inside layouts.
+    (modify-syntax-entry ?\[ "."     table)
+    (modify-syntax-entry ?\] "."     table)
+
+    ;; We highlight the necessary strings ourselves.
+    (modify-syntax-entry ?\" "."     table)
+    table))
 
 (defvar kbd-mode--font-lock-keywords nil
   "Keywords to be syntax highlighted")
@@ -156,23 +168,13 @@ Default: t"
         (goto-char (match-end 0))
         (0 font-lock-string-face t))))))
 
-;;; Hacks
-
-;; We don't need to highlight brackets, as they're only used inside layouts.
-(add-hook 'kbd-mode-hook #'(lambda ()
-                             (modify-syntax-entry ?\[ ".")
-                             (modify-syntax-entry ?\] ".")))
-
-;; We highlight the necessary strings ourselves.
-(add-hook 'kbd-mode-hook #'(lambda () (modify-syntax-entry ?\" ".")))
-
 ;;; Define Major Mode
 
 (define-derived-mode kbd-mode lisp-mode "Kbd"
   "Major mode for editing `.kbd' files"
 
+  (set-syntax-table kbd-mode-syntax-table)
   (font-lock-add-keywords 'kbd-mode kbd-mode--font-lock-keywords)
-  (set-syntax-table kbd-mode--comments-table)
 
   ;; TODO: There *has* to be a better way of doing this
   (let ((macro-regexp '(("\\(:?\\(@[^[:space:]]+\\)\\)"

--- a/elisp/kbd-mode.el
+++ b/elisp/kbd-mode.el
@@ -183,7 +183,11 @@ Default: t"
         (font-lock-add-keywords 'kbd-mode macro-regexp)
       (font-lock-remove-keywords 'kbd-mode macro-regexp)))
 
-  (font-lock-flush))
+  ;; HACK: Otherwise the `syntax-table' refreshes more often than our
+  ;;       `font-lock' settings, causing strings to be un-highlighted.
+  (defadvice redisplay (after refresh-font-locking activate)
+    (when (derived-mode-p 'kbd-mode)
+      (font-lock-fontify-buffer))))
 
 (provide 'kbd-mode)
 ;;; kbd-mode.el ends here


### PR DESCRIPTION
This is in response to #69, trying to get some proper syntax highlighting working for Emacs.  ~~It's a [WIP] because, while I've been using it for some time and the basic functionality works great, some things turned out harder than expected and my elisp knowledge coming to it's end (also there's no documentation yet).  It's quite full of hacks but I suppose that's the elisp way :>~~

~~The basic highlighting (comments, keywords, etc.) is all done, the difficult part is getting quotes to play nicely.  Because in kmonad we often explicitly write `"` in the config file (and expect that to *not* be the start of a string) there are many situation where we don't actually want the "I'm inside a string right now" syntax highlight.  However, at times we *do* want that (e.g. when defining `uinput-sink`), so disabling syntax highlighting for quotes entirely does not sounds very desirable either.~~

~~Currently, it sort of works for `device-file`, but I don't quite know how to expand that regexp to the other candidates yet.~~

EDIT: Most of things should be working now.