### PR TITLE
Add note about Emacs editor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ For information on how to configure KMonad, we refer you to:
 Want to add your configuration to `./keymap`? Fork KMonad, create a new
 subdirectory using your github username and submit a pull-request.
 
+## Editor Support for the Configuration Language
+- [Emacs](https://github.com/slotThe/kbd-mode)
+
 ## Troubleshooting
 For a number of commonly asked questions regarding various configuration issues,
 please see:


### PR DESCRIPTION
As promised, this is the updated pull-request with only a documentation change, pointing at the [new repo](https://github.com/slotThe/kbd-mode) that now holds the Emacs mode.  

It's against `master` because the mode is usuable with `0.4.1`.