### PR TITLE
Consume whitespace after parsing a word

### DIFF
--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -248,12 +248,12 @@ buttonP = (lexeme . choice . map try $
   , statement "tap-hold-next-release"
     $ KTapHoldNextRelease <$> lexeme numP <*> buttonP <*> buttonP
   , statement "tap-next"       $ KTapNext     <$> buttonP     <*> buttonP
-  , statement "layer-toggle"   $ KLayerToggle <$> word
-  , statement "layer-switch"   $ KLayerSwitch <$> word
-  , statement "layer-add"      $ KLayerAdd    <$> word
-  , statement "layer-rem"      $ KLayerRem    <$> word
-  , statement "layer-delay"    $ KLayerDelay  <$> lexeme numP <*> word
-  , statement "layer-next"     $ KLayerNext   <$> word
+  , statement "layer-toggle"   $ KLayerToggle <$> lexeme word
+  , statement "layer-switch"   $ KLayerSwitch <$> lexeme word
+  , statement "layer-add"      $ KLayerAdd    <$> lexeme word
+  , statement "layer-rem"      $ KLayerRem    <$> lexeme word
+  , statement "layer-delay"    $ KLayerDelay  <$> lexeme numP <*> lexeme word
+  , statement "layer-next"     $ KLayerNext   <$> lexeme word
   , statement "around-next"    $ KAroundNext  <$> buttonP
   , statement "tap-macro"      $ KTapMacro    <$> some buttonP
   , statement "cmd-button"     $ KCommand     <$> textP


### PR DESCRIPTION
When applying the 'word' parser, it's often nice to be able to just ignore any
whitespace that follows.  This allows for nicely aligning things, like

```
(defalias
  layer1 (layer-toggle n                    )
  layer2 (layer-switch longername           )
  layer3 (layer-switch longestnamedefinitely))
```

As well as inserting comments in between these definitions

```
(defalias
  l1d (layer-delay
       ;; Some comment or other
       500
       ;; Another one
       layer1))
```

As we're only ignoring whitespace, this *shouldn't* interfere with any existing
configurations (I've tested it with a few of the user configs here and this does
indeed seem to be the case).