### PR TITLE
update "vou" user layout: add some non-default Unicode symbols

### DIFF
--- a/keymap/user/MaxGyver83/.XCompose
+++ b/keymap/user/MaxGyver83/.XCompose
@@ -1,0 +1,8 @@
+include "%L"
+
+<Multi_key> <s> <l> : "ℓ"   # script small l
+<Multi_key> <t> <u> : "👍"  # thumb up
+<Multi_key> <y> <y> : "✔"   # yes yes
+<Multi_key> <n> <n> : "✘"   # no no
+<Multi_key> <s> <t> : "⭐"  # star
+

--- a/keymap/user/MaxGyver83/Neo-layout-in-KMonad.md
+++ b/keymap/user/MaxGyver83/Neo-layout-in-KMonad.md
@@ -19,7 +19,9 @@ There are already many Neo/AdnW/KOY/Bone implementations/drivers available for W
 
 This config contains empty layers 5 and 6 because greek characters can't be inserted as easy as typing them into the config file. You need to use compose sequences (defined in *WinCompose* or `~/.XCompose`). I have inserted these layers just for showing how to implement layers dependent on other layers (technically you switch to layer 2 or 3 when holding down Shift or Mod3 before you can reach layer 5). (There are layers 5 and 6 defined in a block comment but with all symbols in a wrong order, actually matching the VOU layout).
 
-You can switch temporarily to QWERTZ (and back) by pressing `CapsLock+F6`.
+Level 2 is special: The left shift key is defined as a Neo level 2 modifier. So you get the right symbols when you type `lsft` + number but this key doesn't work for `shift` + `home` or `shift` + mouse click. In these cases you have to use the right shift key. But you'll get QWERTY's level 2 when using `rsft` + number. Both shift keys work for creating capital letters, though. (See Issue #111.)
+
+You can switch temporarily to QWERTZ (and back) by pressing `CapsLock+F6` (not completely QWERTZ, `shift` + number gives you QWERTY symbols).
 
 The caps lock functionality (holding down both shift keys) and level 4 lock are not yet implemented.
 
@@ -32,6 +34,6 @@ By the way, KMonad is designed to be based on US keyboard layouts. So `neo.kbd` 
 
 It shows how to have modifiers in the home row (letter when tapped, modifier when held down).
 
-I don't use Neo's layers 5 and 6 but I have defined a `special` layer instead. I use it for switching tabs (in almost every program) and for going back and forth in Firefox and fish.
+I don't use Neo's layers 5 and 6 but I have defined a `special` layer instead. I use it for switching tabs (in almost every program), switching buffers in vim and for going back and forth in Firefox and fish.
 
-This layout also has defined (but not activated) some aliases for umlauts. If you replace `o` with `@o` in your `level1` definition, you get `ö` when holding `o` for at least 200 ms. If you use `@oo` instead, you get `multi-tap` behaviour: Tapping `o` once = `o`, twice = `ö`, three times = `oo`.
+This layout also has defined some aliases for umlauts (but not all activated). For example, you get `ö` when holding `o` for at least 300 ms. If you use `@oo` instead of `@ö`, you get `multi-tap` behaviour: Tapping `o` once = `o`, twice = `ö`, three times = `oo`.

--- a/keymap/user/MaxGyver83/vou.kbd
+++ b/keymap/user/MaxGyver83/vou.kbd
@@ -31,19 +31,18 @@
 (deflayer level1
               C-pgup C-pgdn          f6
   tab       1    2    3    4    5    6    7    8    9    0    -    =
-  lmet      v    .    o    u    ä    q    g    @lsp h    f    j    ´
+  lmet      v    .    @o   u    ä    q    g    @lsp h    f    j    ´
   @lv3      @cs  @aw  @ec  @i4  y    b    @t4  @rc  @nw  @ss  @lv3 ß
-  @lv2 @lv4 z    @xa  @,3  ü    ö    p    @d3  @wa  m    k    rsft
-  lmet      lctl lalt          spc             XX   rmet _    _
+  lsft @j2  @z   @xa  @,3  ü    ö    p    @d3  @wa  m    k    rsft
+  lmet      lctl lalt          spc             XX   rmet _    @ctlc
 )
 
 (deflayer level2
                  f2   f3             _
-;;S-tab     °    §    ℓ    »    «    $    €    „    “    ”    —    ¸
-  S-tab     !    "    §    $    %    &    /    \(   \)   =    ?    ´
+  S-tab     °    §    @ℓ   »    «    $    €    „    “    ”    —    ¸
   lmet      V    •    O    U    Ä    Q    G    L    H    F    J    ´
   _         C    A    E    I    Y    B    T    R    N    S    _    ß
-  @lv2 @lv4 Z    X    -    ü    Ö    P    D    W    M    K    @lv2
+  XX    J   Z    X    -    @Ü   Ö    P    D    W    M    K    XX
   lmet      lctl lalt          spc             @lv4 rmet _    _
 )
 
@@ -51,15 +50,15 @@
                  _   _               @qwe
   _         ¹    ²    ³    ›    ‹    ¢    ¥    ‚    ‘    ’    _    _
   _         @    %    {    }    ^    !    <    >    =    &    €    /
-  _         |    `    \(   \)   *    ?    /    :    -    \_   →    _
-  _    _    #    [    ]    ~    $    +    "    '    \    ;    _
+  _         |    `    \(   \)   *    ?    /    :    -    \_   _    →
+  _    _    #    [    ]    ~    $    +    S-'  '    \    ;    _
   _         _    _              _              _    _    _    _
 )
 
 (deflayer level4
                  _    _              f6
-  _         ¹    ²    ³    ›    ‹    ¢    ¥    ‚    ‘    ’    _    _
-  _         pgup pgdn up   bspc del  :    7    8    9    +    -    "
+  _         ¹    ²    @✔   @✘   @⭐  ¢    ¥    ‚    ‘    ’    _    _
+  _         pgup pgdn up   bspc del  :    7    8    9    +    -    S-'
   _         home lft  down rght end  -    4    5    6    ,    _    ;
   lsft XX   ins  tab  ret  esc  _    _    1    2    3    .    rsft
   _         _    _              0              _    _    _    _
@@ -68,9 +67,9 @@
 (deflayer special
                   XX    XX                XX
   XX        XX    XX    XX    XX    XX    XX    XX    XX    XX    XX    XX    XX
-  XX        XX    XX    XX    XX    XX    XX    XX    XX    XX    XX    XX    XX
+  XX      A-pgup A-pgdn XX    XX    XX    XX    XX    XX    XX    XX    XX    XX
   XX      A-lft C-pgup  XX C-pgdn A-rght  XX    XX    XX    XX    XX    XX    XX
-  XX   XX   XX    XX    XX    XX    XX    XX    XX    XX    XX    XX    XX
+  XX   XX   XX    @pb   @nb   XX    XX    XX    XX    XX    XX    XX    XX
   XX        XX    XX          XX                      XX    XX    XX    XX
 )
 
@@ -111,17 +110,18 @@
 )
 
 (defalias
-  a (tap-hold 200 a ä)
-  o (tap-hold 200 o ö)
-  u (tap-hold 200 u ü)
-  z (tap-hold 200 z ß)
+  a (tap-hold 300 a ä)
+  o (tap-hold 300 o ö)
+  u (tap-hold 300 u ü)
+  z (tap-hold 300 z ß)
 )
 
 (defalias
-  cs (tap-hold-next-release 500 c @lv2)
+  cs (tap-hold-next-release 500 c lsft)
   aw (tap-hold-next-release 500 a lmet)
   ec (tap-hold-next-release 500 e lctl)
   i4 (tap-hold-next-release 500 i @lv4)
+  j2 (tap-hold-next-release 500 j @lv2)
   xa (tap-hold-next-release 500 x lalt)
   ,3 (tap-hold-next-release 500 , @lv3)
 
@@ -132,5 +132,23 @@
   rc  (tap-hold-next-release 500 r rctl)
   nw  (tap-hold-next-release 500 n rmet)
   ss  (tap-hold-next-release 500 s rsft)
+
+  ;; ralt = compose key when tapped, rctl when held down
+  ctlc (tap-hold-next-release 500 ralt rctl)
 )
 
+(defalias
+  ;; vim prev/next buffer
+  pb #(esc : b p ret)
+  nb #(esc : b n ret)
+)
+
+(defalias
+  ;; some unicode characters need to be defined in ~/.XCompose
+  ;; (if you use Windows, you have to define something like this in WinCompose)
+  ℓ  #(ralt s l)  ;; script small l (ℓ)
+  Ü  #(ralt " U)  ;; capital Ü (not necessary in commit b7214c4 or newer)
+  ✔  #(ralt y y)  ;; heavy checkmark (✔)
+  ✘  #(ralt n n)  ;; heavy ballot (✘)
+  ⭐ #(ralt s t)  ;; star (⭐)
+)


### PR DESCRIPTION
vou.xkb:
- add non-default Unicode characters plus example `.XCompose`
- fix layer 2 for number keys
- activate `tap-hold` for `o`/`ö` and `z`/`ß`
- don't try to toggle level 2 when level 2 is active (see Issue #119)
- add alias for `Ü` because `Ü` does not yet work by default in KMonad 0.4.1
- replace `"` by `S-'` (same effect but improved syntax highlighting in vim)
- make right ctrl key a compose key when tapped

documentation:
- explain why left and right shift key do different things in `neo.kbd`