### PR TITLE
Close non-essential file descriptors when spawning a new process

### DIFF
--- a/src/KMonad/App.hs
+++ b/src/KMonad/App.hs
@@ -18,7 +18,7 @@ where
 
 import KMonad.Prelude
 
-import UnliftIO.Process (spawnCommand)
+import UnliftIO.Process (CreateProcess(close_fds), createProcess_, shell)
 import RIO.Text (unpack)
 
 import KMonad.Action
@@ -221,9 +221,13 @@ instance (HasAppEnv e, HasAppCfg e, HasLogFunc e) => MonadKIO (RIO e) where
     f <- view allowCmd
     if f then do
       logInfo $ "Running command: " <> display t
-      void . spawnCommand . unpack $ t
+      spawnCommand . unpack $ t
     else
       logInfo $ "Received but not running: " <> display t
+   where
+    spawnCommand :: MonadIO m => String -> m ()
+    spawnCommand cmd =
+      createProcess_ "spawnCommand" (shell cmd){ close_fds = True } $> ()
 
 --------------------------------------------------------------------------------
 -- $kenv


### PR DESCRIPTION
For convenience, this is the patch from #92 (against `master` as you said in the thread)