### PR TITLE
[WIP] Create CLI for all Options in DefCfg

### DIFF
--- a/src/KMonad/Args.hs
+++ b/src/KMonad/Args.hs
@@ -36,15 +36,15 @@ runCmd :: Cmd -> IO ()
 runCmd c = do
   o <- logOptionsHandle stdout False <&> setLogMinLevel (c^.logLvl)
   withLogFunc o $ \f -> runRIO f $ do
-    cfg <- loadConfig $ c^.cfgFile
+    cfg <- loadConfig c
     unless (c^.dryRun) $ startApp cfg
 
 -- | Parse a configuration file into a 'AppCfg' record
-loadConfig :: HasLogFunc e => FilePath -> RIO e AppCfg
-loadConfig pth = do
+loadConfig :: HasLogFunc e => Cmd -> RIO e AppCfg
+loadConfig cmd = do
 
-  tks <- loadTokens pth   -- This can throw a PErrors
-  cgt <- joinConfigIO tks -- This can throw a JoinError
+  tks <- loadTokens (cmd^.cfgFile)      -- This can throw a PErrors
+  cgt <- joinConfigIO (joinCLI cmd tks) -- This can throw a JoinError
 
   -- Try loading the sink and src
   lf  <- view logFuncL
@@ -60,3 +60,35 @@ loadConfig pth = do
     , _fallThrough  = _flt   cgt
     , _allowCmd     = _allow cgt
     }
+
+-- | Join the options given from the command line with the one read from the
+-- configuration file.
+-- This does not yet throw any kind of exception, as we are simply inserting the
+-- given options into every 'KDefCfg' block that we see.
+joinCLI :: Cmd -> [KExpr] -> [KExpr]
+joinCLI cmd = traverse._KDefCfg %~ insertCliOption cliList
+ where
+  -- | All options and flags that were given on the command line.
+  cliList :: DefSettings
+  cliList = catMaybes $
+       map flagToMaybe [cmd^.cmdAllow, cmd^.fallThrgh]
+    <> [cmd^.iToken, cmd^.oToken, cmd^.cmpSeq, cmd^.initStr]
+
+  -- | Convert command line flags to a 'Maybe' type, where the non-presence, as
+  -- well as the default value of a flag will be interpreted as @Nothing@
+  flagToMaybe :: DefSetting -> Maybe DefSetting
+  flagToMaybe = \case
+    SAllowCmd    b -> if b then Just (SAllowCmd    b) else Nothing
+    SFallThrough b -> if b then Just (SFallThrough b) else Nothing
+    _              -> Nothing
+
+  -- | Insert all command line options, potentially overwriting already existing
+  -- options that were given in the configuration file. This is a paramorphism
+  insertCliOption :: DefSettings -> DefSettings -> DefSettings
+  insertCliOption cliSettings cfgSettings =
+    foldr (\s cfgs ->
+             if   s `elem` cfgs
+             then foldr (\x xs -> (if s == x then s else x) : xs) [] cfgs
+             else s : cfgs)
+          cfgSettings
+          cliSettings

--- a/src/KMonad/Args/Cmd.hs
+++ b/src/KMonad/Args/Cmd.hs
@@ -16,7 +16,11 @@ module KMonad.Args.Cmd
   )
 where
 
-import KMonad.Prelude
+import KMonad.Prelude hiding (try)
+import KMonad.Args.Parser (itokens, keywordButtons, noKeywordButtons, otokens, symbol)
+import KMonad.Args.Types (DefSetting(..), choice, try)
+
+import qualified KMonad.Args.Types as M  -- [M]egaparsec functionality
 
 import Options.Applicative
 
@@ -28,9 +32,17 @@ import Options.Applicative
 
 -- | Record describing the instruction to KMonad
 data Cmd = Cmd
-  { _cfgFile :: FilePath -- ^ Which file to read the config from
-  , _dryRun  :: Bool     -- ^ Flag to indicate we are only test-parsing
-  , _logLvl  :: LogLevel -- ^ Level of logging to use
+  { _cfgFile   :: FilePath -- ^ Which file to read the config from
+  , _dryRun    :: Bool     -- ^ Flag to indicate we are only test-parsing
+  , _logLvl    :: LogLevel -- ^ Level of logging to use
+
+    -- All 'KDefCfg' options of a 'KExpr'
+  , _cmdAllow  :: DefSetting       -- ^ Allow execution of arbitrary shell-commands?
+  , _fallThrgh :: DefSetting       -- ^ Re-emit unhandled events?
+  , _initStr   :: Maybe DefSetting -- ^ TODO: What does this do?
+  , _cmpSeq    :: Maybe DefSetting -- ^ Key to use for compose-key sequences
+  , _oToken    :: Maybe DefSetting -- ^ How to emit the output
+  , _iToken    :: Maybe DefSetting -- ^ How to capture the input
   }
   deriving Show
 makeClassy ''Cmd
@@ -51,7 +63,16 @@ getCmd = customExecParser (prefs showHelpOnEmpty) $ info (cmdP <**> helper)
 
 -- | Parse the full command
 cmdP :: Parser Cmd
-cmdP = Cmd <$> fileP <*> dryrunP <*> levelP
+cmdP =
+  Cmd <$> fileP
+      <*> dryrunP
+      <*> levelP
+      <*> cmdAllowP
+      <*> fallThrghP
+      <*> initStrP
+      <*> cmpSeqP
+      <*> oTokenP
+      <*> iTokenP
 
 -- | Parse a filename that points us at the config-file
 fileP :: Parser FilePath
@@ -79,3 +100,64 @@ levelP = option f
     f = maybeReader $ flip lookup [ ("debug", LevelDebug), ("warn", LevelWarn)
                                   , ("info",  LevelInfo),  ("error", LevelError) ]
 
+-- | Allow the execution of arbitrary shell-commands
+cmdAllowP :: Parser DefSetting
+cmdAllowP = SAllowCmd <$> switch
+  (  long "allow-cmd"
+  <> short 'c'
+  <> help "Whether to allow the execution of arbitrary shell-commands"
+  )
+
+-- | Re-emit unhandled events
+fallThrghP :: Parser DefSetting
+fallThrghP = SFallThrough <$> switch
+  (  long "fallthrough"
+  <> short 'f'
+  <> help "Whether to simply re-emit unhandled events"
+  )
+
+-- | TODO what does this do?
+initStrP :: Parser (Maybe DefSetting)
+initStrP = optional $ SInitStr <$> strOption
+  (  long "init"
+  <> short 'i'
+  <> metavar "STRING"
+  <> help "TODO"
+  )
+
+-- | Key to use for compose-key sequences
+cmpSeqP :: Parser (Maybe DefSetting)
+cmpSeqP = optional $ SCmpSeq <$> option
+  (tokenParser keywordButtons <|> megaReadM (choice noKeywordButtons))
+  (  long "cmp-seq"
+  <> short 'c'
+  <> metavar "BUTTON"
+  <> help "Which key to use to emit compose-key sequences"
+  )
+
+-- | Where to emit the output
+oTokenP :: Parser (Maybe DefSetting)
+oTokenP = optional $ SOToken <$> option (tokenParser otokens)
+  (  long "output"
+  <> short 'o'
+  <> metavar "OTOKEN"
+  <> help "Emit output to OTOKEN"
+  )
+
+-- | How to capture the keyboard input
+iTokenP :: Parser (Maybe DefSetting)
+iTokenP = optional $ SIToken <$> option (tokenParser itokens)
+  (  long "input"
+  <> short 'i'
+  <> metavar "ITOKEN"
+  <> help "Capture input via ITOKEN"
+  )
+
+-- | Transform a bunch of tokens of the form @(Keyword, Parser)@ into an
+-- optparse-applicative parser
+tokenParser :: [(Text, M.Parser a)] -> ReadM a
+tokenParser = megaReadM . choice . map (try . uncurry ((*>) . symbol))
+
+-- | Megaparsec <--> optparse-applicative interface
+megaReadM :: M.Parser a -> ReadM a
+megaReadM p = eitherReader (mapLeft show . M.parse p "" . fromString)

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -143,8 +143,8 @@ numP = L.decimal
 -- | Parse text with escaped characters between "s
 textP :: Parser Text
 textP = do
-  _ <- char '\"'
-  s <- manyTill L.charLiteral (char '\"')
+  _ <- char '\"' <|> char '\''
+  s <- manyTill L.charLiteral (char '\"' <|> char '\'')
   pure . T.pack $ s
 
 -- | Parse a variable reference

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -16,8 +16,18 @@ This module covers step 1.
 
 -}
 module KMonad.Args.Parser
-  ( parseTokens
+  ( -- * Parsing 'KExpr's
+    parseTokens
   , loadTokens
+
+  -- * Building Parsers
+  , symbol
+
+  -- * Parsers for Tokens and Buttons
+  , otokens
+  , itokens
+  , keywordButtons
+  , noKeywordButtons
   )
 where
 
@@ -239,26 +249,41 @@ deadkeySeqP = do
 -- | Parse any button
 buttonP :: Parser DefButton
 buttonP = (lexeme . choice . map try $
-  [ statement "around"         $ KAround      <$> buttonP     <*> buttonP
-  , statement "multi-tap"      $ KMultiTap    <$> timed       <*> buttonP
-  , statement "tap-hold"       $ KTapHold     <$> lexeme numP <*> buttonP <*> buttonP
-  , statement "tap-hold-next"  $ KTapHoldNext <$> lexeme numP <*> buttonP <*> buttonP
-  , statement "tap-next-release"
-    $ KTapNextRelease <$> buttonP <*> buttonP
-  , statement "tap-hold-next-release"
-    $ KTapHoldNextRelease <$> lexeme numP <*> buttonP <*> buttonP
-  , statement "tap-next"       $ KTapNext     <$> buttonP     <*> buttonP
-  , statement "layer-toggle"   $ KLayerToggle <$> lexeme word
-  , statement "layer-switch"   $ KLayerSwitch <$> lexeme word
-  , statement "layer-add"      $ KLayerAdd    <$> lexeme word
-  , statement "layer-rem"      $ KLayerRem    <$> lexeme word
-  , statement "layer-delay"    $ KLayerDelay  <$> lexeme numP <*> lexeme word
-  , statement "layer-next"     $ KLayerNext   <$> lexeme word
-  , statement "around-next"    $ KAroundNext  <$> buttonP
-  , statement "tap-macro"      $ KTapMacro    <$> some buttonP
-  , statement "cmd-button"     $ KCommand     <$> textP
-  , statement "pause"          $ KPause . fromIntegral <$> numP
-  , KComposeSeq <$> deadkeySeqP
+  map (uncurry statement) keywordButtons ++ noKeywordButtons
+  ) <?> "button"
+
+-- | Parsers for buttons that have a keyword at the start; the format is
+-- @(keyword, how to parse the token)@
+keywordButtons :: [(Text, Parser DefButton)]
+keywordButtons =
+  [ ("around"         , KAround      <$> buttonP     <*> buttonP)
+  , ("multi-tap"      , KMultiTap    <$> timed       <*> buttonP)
+  , ("tap-hold"       , KTapHold     <$> lexeme numP <*> buttonP <*> buttonP)
+  , ("tap-hold-next"  , KTapHoldNext <$> lexeme numP <*> buttonP <*> buttonP)
+  , ("tap-next-release"
+    , KTapNextRelease <$> buttonP <*> buttonP)
+  , ("tap-hold-next-release"
+    , KTapHoldNextRelease <$> lexeme numP <*> buttonP <*> buttonP)
+  , ("tap-next"       , KTapNext     <$> buttonP     <*> buttonP)
+  , ("layer-toggle"   , KLayerToggle <$> lexeme word)
+  , ("layer-switch"   , KLayerSwitch <$> lexeme word)
+  , ("layer-add"      , KLayerAdd    <$> lexeme word)
+  , ("layer-rem"      , KLayerRem    <$> lexeme word)
+  , ("layer-delay"    , KLayerDelay  <$> lexeme numP <*> lexeme word)
+  , ("layer-next"     , KLayerNext   <$> lexeme word)
+  , ("around-next"    , KAroundNext  <$> buttonP)
+  , ("tap-macro"      , KTapMacro    <$> some buttonP)
+  , ("cmd-button"     , KCommand     <$> textP)
+  , ("pause"          , KPause . fromIntegral <$> numP)
+  ]
+ where
+  timed :: Parser [(Int, DefButton)]
+  timed = many ((,) <$> lexeme numP <*> lexeme buttonP)
+
+-- | Parsers for buttons that do __not__ have a keyword at the start
+noKeywordButtons :: [Parser DefButton]
+noKeywordButtons =
+  [ KComposeSeq <$> deadkeySeqP
   , KRef  <$> derefP
   , lexeme $ fromNamed buttonNames
   , try moddedP
@@ -266,28 +291,32 @@ buttonP = (lexeme . choice . map try $
   , lexeme $ try pauseP
   , KEmit <$> keycodeP
   , KComposeSeq <$> composeSeqP
-  ]) <?> "button"
-
-  where
-    timed = many ((,) <$> lexeme numP <*> lexeme buttonP)
-
+  ]
 
 --------------------------------------------------------------------------------
 -- $defcfg
 
 -- | Parse an input token
 itokenP :: Parser IToken
-itokenP = choice . map try $
-  [ statement "device-file"    $ KDeviceSource <$> (T.unpack <$> textP)
-  , statement "low-level-hook" $ pure KLowLevelHookSource
-  , statement "iokit-name"     $ KIOKitSource <$> optional textP]
+itokenP = choice $ map (try . uncurry statement) itokens
+
+-- | Input tokens to parse; the format is @(keyword, how to parse the token)@
+itokens :: [(Text, Parser IToken)]
+itokens =
+  [ ("device-file"   , KDeviceSource <$> (T.unpack <$> textP))
+  , ("low-level-hook", pure KLowLevelHookSource)
+  , ("iokit-name"    , KIOKitSource <$> optional textP)]
 
 -- | Parse an output token
 otokenP :: Parser OToken
-otokenP = choice . map try $
-  [ statement "uinput-sink"     $ KUinputSink <$> lexeme textP <*> optional textP
-  , statement "send-event-sink" $ pure KSendEventSink
-  , statement "kext"            $ pure KKextSink]
+otokenP = choice $ map (try . uncurry statement) otokens
+
+-- | Output tokens to parse; the format is @(keyword, how to parse the token)@
+otokens :: [(Text, Parser OToken)]
+otokens =
+  [ ("uinput-sink"    , KUinputSink <$> lexeme textP <*> optional textP)
+  , ("send-event-sink", pure KSendEventSink)
+  , ("kext"           , pure KKextSink)]
 
 -- | Parse the DefCfg token
 defcfgP :: Parser DefSettings
@@ -323,4 +352,3 @@ defsrcP = many $ lexeme keycodeP
 -- $deflayer
 deflayerP :: Parser DefLayer
 deflayerP = DefLayer <$> lexeme word <*> many (lexeme buttonP)
-

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -171,6 +171,18 @@ data DefSetting
   deriving Show
 makeClassyPrisms ''DefSetting
 
+-- | 'Eq' instance for a 'DefSetting'. Because every one of these options may be
+-- given at most once, we only need to check the outermost constructor in order
+-- to test for equality
+instance Eq DefSetting where
+  SIToken{}      == SIToken{}      = True
+  SOToken{}      == SOToken{}      = True
+  SCmpSeq{}      == SCmpSeq{}      = True
+  SInitStr{}     == SInitStr{}     = True
+  SFallThrough{} == SFallThrough{} = True
+  SAllowCmd{}    == SAllowCmd{}    = True
+  _              == _              = False
+
 -- | A list of different 'DefSetting' values
 type DefSettings = [DefSetting]
 


### PR DESCRIPTION
This is in partial response to the discussion in #90.  It basically (so far) implements the following:

> Any all defcfg entries should have command-line ways of specifying them, and these should always override defcfg if provided on the command line.

I marked this as a WIP because there are still some things I'm not sure about.

  1. What is the purpose of `SInitStr`?  Unless I'm going crazy, this seems to be just ignored in `KMonad.Args.Joiner`!  There are still TODOs in the source file for it for this reason.
  2. I summoned an (ugly) `Eq` instance for `DefSetting`, comparing only the outermost constructor.  This makes sense right now because we only allow a single e.g. output token to be specified in the config file.  Should this ever change then this instance would need to change with it (or, realistically, be deleted entirely).
  3. `joinCLI` is not the prettiest function, but so far I can't think of a better way to incorporate command line options into the config options while also maintaining certain invariants (like the number of config options specified, in case we have to bail out with a `DuplicateSetting` exception).

One could argue that 2. and 3. are connected.  If we allowed several options (and perhaps even `defcfg` blocks) to be specified, then a simpler implementation could be found.  However, if we don't just want to pick the first specified block but one that "works", the question arises what "works" even means in this context (and what if we have two specifications that work?).  I went with the "easy" way for now, because I quite frankly don't know the answer to a lot of these ambiguity questions (though I would be prepared to rewrite this if you do).   


At the moment, command line options may be specified in the following way:

```shell
kmonad -o "uinput-sink 'NAME' 'sleep 0.2s; xset r rate 230 70'" -f -c /path/to/config
```
Note the missing parenthesis around the output token, as well as the string being inside single quotes; I thought that this would be a decent quality-of-life improvement over using normal sexp syntax in the CLI.