### PR TITLE
Document cmp-seq

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -47,6 +47,11 @@ tries to stay as close to the kernel as possible, so you can run it on other
 OSes or without X11. If you want `Hyper_L` to work, you have to make sure that
 X11 lines up well with KMonad. See [this issue](https://github.com/david-janssen/kmonad/issues/22) for more explanation.
 
+### Q: How does Unicode entry work?
+
+A: Unicode entry works via X11 compose-key sequences. For information on how to
+configure kmonad to make use of this, please see [the tutorial](../keymap/tutorial.kbd).
+
 ## Windows
 
 ### How do I start KMonad?
@@ -61,8 +66,8 @@ command-line utility, so, to run it you need to:
 
 2. 'cd' to where you've stored KMonad, like this:
 ```powershell
-cd "C:\Users\david\Desktop\Just an Example" 
-``` 
+cd "C:\Users\david\Desktop\Just an Example"
+```
 NOTE: The double-tick marks around the path let you easily use directories with
 spaces in the names.
 

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -72,6 +72,14 @@
       (cmd-button "rm -rf ~/*")
     is a thing.
 
+  There are also some optional OS specific settings that we support:
+
+  - `cmp-seq': KEY, defaults to `RightAlt' (Linux X11 specific)
+
+    This sets your compose key for Unicode input. For more information, as well
+    as a workaround to also make this work on windows, see the section on
+    Compose-key sequences below.
+
   Secondly, let's go over how to specify the `input` and `output` fields of a
   `defcfg` block. This differs between OS'es, and so do the capabilities of
   these interfaces.
@@ -136,6 +144,7 @@
     ;; To understand the importance of the following line, see the section on
     ;; Compose-key sequences at the near-bottom of this file.
     "/run/current-system/sw/bin/sleep 1 && /run/current-system/sw/bin/setxkbmap -option compose:ralt")
+  cmp-seq ralt  ;; Set the compose key to `RightAlt'
 
   ;; For Windows
   ;; input  (low-level-hook)
@@ -542,7 +551,7 @@
   These two operations together, however, are very useful for activating a
   permanent overlay for a while. This technique is illustrated in the tap-hold
   overlay a bit further down.
-   
+
 
   -------------------------------------------------------------------------- |#
 
@@ -771,15 +780,24 @@
   characters, or various special-languages. In that sense, they are just
   syntactic sugar for keyboard macros.
 
-  To get this to work on Linux you will need to set your compose-key to RightAlt
-  (customization of this option is forthcoming). The line in the `defcfg` block
-  at the top of this file should work. Note that you need to wait ever so
-  slightly for the keyboard to register with linux before the command gets
-  executed, that's why the `sleep 1`. Also, note that all the
-  `/run/current-system` stuff is because the author uses NixOS. Just find a
+  To get this to work on Linux you will need to set your compose-key with a tool
+  like `setxkbmap', as well as tell kmonad that information. See the `defcfg'
+  block at the top of this file for a working example. Note that you need to
+  wait ever so slightly for the keyboard to register with linux before the
+  command gets executed, that's why the `sleep 1`. Also, note that all the
+  `/run/current-system' stuff is because the author uses NixOS. Just find a
   shell-command that will:
-  1. Sleep a moment
-  2. Set the compose-key to ralt
+
+    1. Sleep a moment
+    2. Set the compose-key to your desired key
+
+  Please be aware that what `setxkbmap' calls the `menu' key is not actually the
+  `menu' key! If you want to use the often suggested
+
+      setxkbmap -option compose:menu
+
+  you will have to set your compose key within kmonad to `compose' and not
+  `menu'.
 
   After this, this should work out of the box under Linux. Windows does not
   recognize the same compose-key sequences, but WinCompose will make most of the


### PR DESCRIPTION
As discussed in #143, this commit adds some documentation of the (hitherto undocumented) feature of setting one's own compose-key.  There's also a small gotcha with the `menu` and `compose` situation, which was added to the tutorial.  I also add an entry into the FAQ, so as to help with discoverability.

This pr is against master, as the feature is already present in the current master (the tutorial just wrongfully tells you it's not yet implemented).