### PR TITLE
Add ability to execute shell command on release of cmd-button

### DIFF
--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -68,8 +68,11 @@
     If this is set to `false`, any action that runs a shell-command will simply
     log to `stdout` without ever running (log-level info). Don't ever enable
     this on a configuration that you do not trust, because:
+
       (cmd-button "rm -rf ~/*")
-    is a thing.
+
+    is a thing. For more information on the `cmd-button' function, see the
+    section on Command buttons below.
 
   Secondly, let's go over how to specify the `input` and `output` fields of a
   `defcfg` block. This differs between OS'es, and so do the capabilities of
@@ -813,8 +816,13 @@
   NOTE: currently only tested on Linux, but should work on any platform, as long
   as the command is valid for that platform.
 
+  The `cmd-button' function takes two arguments, the second one of which is
+  optional. These represent the commands to be executed on pressing and
+  releasing the button respectively.
+
   BEWARE: never run anyone's configuration without looking at it. You wouldn't
   want to push:
+
     (cmd-button "rm -rf ~/*") ;; Delete all this user's data
 
 
@@ -823,6 +831,9 @@
 (defalias
   dat (cmd-button "date >> /tmp/kmonad_example.txt")   ;; Append date to tmpfile
   pth (cmd-button "echo $PATH > /tmp/kmonad_path.txt") ;; Write out PATH
+  ;; `dat' on press and `pth' on release
+  bth (cmd-button "date >> /tmp/kmonad_example.txt"
+                  "echo $PATH > /tmp/kmonad_path.txt")
 )
 
 (deflayer command-test

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -329,7 +329,7 @@ joinButton ns als =
 
     -- Various simple buttons
     KEmit c -> ret $ emitB c
-    KCommand t -> ret $ cmdButton t
+    KCommand pr mbR -> ret $ cmdButton pr mbR
     KLayerToggle t -> if t `elem` ns
       then ret $ layerToggle t
       else throwError $ MissingLayer t

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -273,7 +273,7 @@ keywordButtons =
   , ("layer-next"     , KLayerNext   <$> lexeme word)
   , ("around-next"    , KAroundNext  <$> buttonP)
   , ("tap-macro"      , KTapMacro    <$> some buttonP)
-  , ("cmd-button"     , KCommand     <$> textP)
+  , ("cmd-button"     , KCommand     <$> lexeme textP <*> optional (lexeme textP))
   , ("pause"          , KPause . fromIntegral <$> numP)
   ]
  where

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -95,7 +95,8 @@ data DefButton
   | KPause Milliseconds                    -- ^ Pause for a period of time
   | KLayerDelay Int LayerTag               -- ^ Switch to a layer for a period of time
   | KLayerNext LayerTag                    -- ^ Perform next button in different layer
-  | KCommand Text                          -- ^ Execute a shell command
+  | KCommand Text (Maybe Text)             -- ^ Execute a shell command on press, as well
+                                           --   as possibly on release
   | KTrans                                 -- ^ Transparent button that does nothing
   | KBlock                                 -- ^ Button that catches event
   deriving Show

--- a/src/KMonad/Button.hs
+++ b/src/KMonad/Button.hs
@@ -150,9 +150,10 @@ layerRem t = onPress (layerOp $ PopLayer t)
 pass :: Button
 pass = onPress $ pure ()
 
--- | Create a button that executes a shell command on press
-cmdButton :: Text -> Button
-cmdButton t = onPress $ shellCmd t
+-- | Create a button that executes a shell command on press and possibly on
+-- release
+cmdButton :: Text -> Maybe Text -> Button
+cmdButton pr mbR = mkButton (shellCmd pr) (maybe (pure ()) shellCmd mbR)
 
 --------------------------------------------------------------------------------
 -- $combinators
@@ -351,5 +352,3 @@ layerNext :: LayerTag -> Button
 layerNext t = onPress $ do
   layerOp (PushLayer t)
   await isPress (\_ -> whenDone (layerOp $ PopLayer t) *> pure NoCatch)
-
-


### PR DESCRIPTION
Closes #25. 

With this change, as well as the help of the `around` function, one is
able to use a `cmd-button` for e.g. switching the keyboard layout (via
`setxkbmap` or a similar utility) after toggling a layer and then
switching back to the normal layout after the toggle has been released.