### PR TITLE
[WIP] Delay in tap-macros/compose-key sequences

### DIFF
--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -83,6 +83,13 @@
     as a workaround to also make this work on windows, see the section on
     Compose-key sequences below.
 
+  - `cmp-seq-delay': NUMBER (in milliseconds)
+
+    This sets a delay between each pressed key in a compose-key sequence.  Some
+    environments may have troubles recognizing the key sequence if it's pressed
+    too rapidly; if you experience any problems in this direction, you can try
+    setting this value to `5' or `10' and see if that helps.
+
   Secondly, let's go over how to specify the `input` and `output` fields of a
   `defcfg` block. This differs between OS'es, and so do the capabilities of
   these interfaces.
@@ -147,7 +154,8 @@
     ;; To understand the importance of the following line, see the section on
     ;; Compose-key sequences at the near-bottom of this file.
     "/run/current-system/sw/bin/sleep 1 && /run/current-system/sw/bin/setxkbmap -option compose:ralt")
-  cmp-seq ralt  ;; Set the compose key to `RightAlt'
+  cmp-seq ralt    ;; Set the compose key to `RightAlt'
+  cmp-seq-delay 5 ;; 5ms delay between each compose-key sequence press
 
   ;; For Windows
   ;; input  (low-level-hook)
@@ -478,8 +486,19 @@
   the program time to register all the key-presses. Therefore we also provide
   the 'pause' function, which simply pauses processing for a certain amount of
   milliseconds. Pauses can be created like this:
+
     (pause 20)
     P20
+
+  You an also pause between each key stroke by specifying the `:delay' keyword,
+  as well as a time in ms, at the end of a `tap-macro':
+
+    (tap-macro K M o n a d :delay 5)
+    #(K M o n a d :delay 5)
+
+  The above would be equivalent to e.g.
+
+    (tap-macro K P5 M P5 o P5 n P5 a P5 d)
 
   WARNING: DO NOT STORE YOUR PASSWORDS IN PLAIN TEXT OR IN YOUR KEYBOARD
 

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -50,7 +50,7 @@ import KMonad.Keyboard.IO.Mac.KextSink
 
 import Control.Monad.Except
 
-import RIO.List (uncons, headMaybe)
+import RIO.List (headMaybe, intersperse, uncons)
 import RIO.Partial (fromJust)
 import qualified Data.LayerStack  as L
 import qualified RIO.HashMap      as M
@@ -321,6 +321,7 @@ joinButton ns als =
       go     = unnest . joinButton ns als
       jst    = fmap Just
       fi     = fromIntegral
+      isps l = traverse go . maybe l ((`intersperse` l) . KPause . fi)
   in \case
     -- Variable dereference
     KRef t -> case M.lookup t als of
@@ -351,7 +352,7 @@ joinButton ns als =
 
     -- Various compound buttons
     KComposeSeq bs     -> view cmpKey >>= \c -> jst $ tapMacro . (c:) <$> mapM go bs
-    KTapMacro bs       -> jst $ tapMacro           <$> mapM go bs
+    KTapMacro bs mbD   -> jst $ tapMacro           <$> mapM go (isps bs mbD)
     KAround o i        -> jst $ around             <$> go o <*> go i
     KTapNext t h       -> jst $ tapNext            <$> go t <*> go h
     KTapHold s t h     -> jst $ tapHold (fi s)     <$> go t <*> go h

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -230,7 +230,7 @@ getFT = do
     Left None      -> pure False
     Left Duplicate -> throwError $ DuplicateSetting "fallthrough"
 
--- | Extract the fallthrough setting
+-- | Extract the allow-cmd setting
 getAllow :: J Bool
 getAllow = do
   cfg <- oneBlock "defcfg" _KDefCfg
@@ -238,6 +238,15 @@ getAllow = do
     Right b        -> pure b
     Left None      -> pure False
     Left Duplicate -> throwError $ DuplicateSetting "allow-cmd"
+
+-- | Extract the cmp-seq-delay setting
+getCmpSeqDelay :: J (Maybe Int)
+getCmpSeqDelay = do
+  cfg <- oneBlock "defcfg" _KDefCfg
+  case onlyOne . extract _SCmpSeqDelay $ cfg of
+    Right b        -> pure (Just b)
+    Left None      -> pure Nothing
+    Left Duplicate -> throwError $ DuplicateSetting "cmp-seq-delay"
 
 #ifdef linux_HOST_OS
 
@@ -351,8 +360,10 @@ joinButton ns als =
       else throwError $ MissingLayer t
 
     -- Various compound buttons
-    KComposeSeq bs     -> view cmpKey >>= \c -> jst $ tapMacro . (c:) <$> mapM go bs
-    KTapMacro bs mbD   -> jst $ tapMacro           <$> mapM go (isps bs mbD)
+    KComposeSeq bs     -> do csd <- getCmpSeqDelay
+                             c   <- view cmpKey
+                             jst $ tapMacro . (c:) <$> isps bs csd
+    KTapMacro bs mbD   -> jst $ tapMacro           <$> isps bs mbD
     KAround o i        -> jst $ around             <$> go o <*> go i
     KTapNext t h       -> jst $ tapNext            <$> go t <*> go h
     KTapHold s t h     -> jst $ tapHold (fi s)     <$> go t <*> go h

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -336,12 +336,13 @@ defcfgP = some (lexeme settingP)
 settingP :: Parser DefSetting
 settingP = let f s p = symbol s *> p in
   (lexeme . choice . map try $
-    [ SIToken      <$> f "input"       itokenP
-    , SOToken      <$> f "output"      otokenP
-    , SCmpSeq      <$> f "cmp-seq"     buttonP
-    , SInitStr     <$> f "init"        textP
-    , SFallThrough <$> f "fallthrough" bool
-    , SAllowCmd    <$> f "allow-cmd"   bool
+    [ SIToken      <$> f "input"         itokenP
+    , SOToken      <$> f "output"        otokenP
+    , SCmpSeq      <$> f "cmp-seq"       buttonP
+    , SInitStr     <$> f "init"          textP
+    , SFallThrough <$> f "fallthrough"   bool
+    , SAllowCmd    <$> f "allow-cmd"     bool
+    , SCmpSeqDelay <$> f "cmp-seq-delay" numP
     ])
 
 --------------------------------------------------------------------------------

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -128,6 +128,11 @@ bool :: Parser Bool
 bool = symbol "true" *> pure True
    <|> symbol "false" *> pure False
 
+-- | Parse a LISP-like keyword of the form @:keyword value@
+keywordP :: Text -> Parser p -> Parser p
+keywordP kw p = lexeme (string (":" <> kw)) *> lexeme p
+  <?> "Keyword " <> ":" <> T.unpack kw
+
 --------------------------------------------------------------------------------
 -- $elem
 --
@@ -222,7 +227,9 @@ pauseP = KPause . fromIntegral <$> (char 'P' *> numP)
 
 -- | #()-syntax tap-macro
 rmTapMacroP :: Parser DefButton
-rmTapMacroP = KTapMacro <$> (char '#' *> paren (some buttonP))
+rmTapMacroP =
+  char '#' *> paren (KTapMacro <$> some buttonP
+                               <*> optional (keywordP "delay" numP))
 
 -- | Compose-key sequence
 composeSeqP :: Parser [DefButton]
@@ -273,7 +280,8 @@ keywordButtons =
   , ("layer-delay"    , KLayerDelay  <$> lexeme numP <*> lexeme word)
   , ("layer-next"     , KLayerNext   <$> lexeme word)
   , ("around-next"    , KAroundNext  <$> buttonP)
-  , ("tap-macro"      , KTapMacro    <$> some buttonP)
+  , ("tap-macro"
+    , KTapMacro <$> lexeme (some buttonP) <*> optional (keywordP "delay" numP))
   , ("cmd-button"     , KCommand     <$> lexeme textP <*> optional (lexeme textP))
   , ("pause"          , KPause . fromIntegral <$> numP)
   , ("sticky-key"     , KStickyKey   <$> lexeme numP <*> buttonP)

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -172,6 +172,7 @@ data DefSetting
   | SInitStr     Text
   | SFallThrough Bool
   | SAllowCmd    Bool
+  | SCmpSeqDelay Int
   deriving Show
 makeClassyPrisms ''DefSetting
 

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -91,7 +91,8 @@ data DefButton
   | KAroundNextSingle DefButton            -- ^ Surround a future button
   | KMultiTap [(Int, DefButton)] DefButton -- ^ Do things depending on tap-count
   | KAround DefButton DefButton            -- ^ Wrap 1 button around another
-  | KTapMacro [DefButton]                  -- ^ Sequence of buttons to tap
+  | KTapMacro [DefButton] (Maybe Int)
+    -- ^ Sequence of buttons to tap, possible delay between each press
   | KComposeSeq [DefButton]                -- ^ Compose-key sequence
   | KPause Milliseconds                    -- ^ Pause for a period of time
   | KLayerDelay Int LayerTag               -- ^ Switch to a layer for a period of time


### PR DESCRIPTION
Fixes #127 

It's a bug fix so it's against `master`

Some systems (such as GNOME 3, apparently) have troubles when compose-key sequences are entered too fast, resulting in mangled output.  The added delay is so small (5 ms) that it should not be percetible for anyone.

Because this is such a tiny (and non-disruptive) change, I'll merge it in a couple of days if no one protests