### PR TITLE
change to multi-keyboard systemd units in nixos

### DIFF
--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -55,16 +55,29 @@ with lib;
 
     systemd = with lib; with builtins;
       let
+        # If only one config file is supplied, unify all kmonad units under a target
         make-group = (length cfg.configfiles + length cfg.optionalconfigs) > 1;
+
+        # All systemd units require the graphics target directly (if a single config),
+        # or indirectly (via kmonad.target).
         wantedBy = [ "graphical.target" ];
+
         mk-kmonad-target = services: {
+          # The kmonad.target allows you to restart all kmonad instances with:
+          #
+          #     systemctl restart kmonad.target
+          #
+          # this works because this unit requires all config-based services
           description = "KMonad target";
           requires = map (service: service.name + ".service") services;
           inherit wantedBy;
         };
+
         mk-kmonad-service = { is-optional }: kbd-path:
           let
+            # prettify the service's name by taking the config filename...
             conf-file = lists.last (strings.splitString "/" (toString kbd-path));
+            # ...and dropping the extension
             conf-name = lists.head (strings.splitString "." conf-file);
           in {
           name = "kmonad-" +conf-name;
@@ -73,17 +86,31 @@ with lib;
             description = "KMonad Instance for: " +conf-name;
             serviceConfig = {
               Type = "simple";
-              ExecStart = "${cfg.package}/bin/kmonad ${kbd-path}" +
-                          (if is-optional then " || true" else "");
+              ExecStart =
+                "${cfg.package}/bin/kmonad ${kbd-path}" +
+                  # kmonad will error on initialization for any unplugged keyboards
+                  # when run in systemd. All optional configs will silently error
+                  #
+                  # TODO: maybe try to restart the unit?
+                  (if is-optional then " || true" else "");
             };
           } // (if make-group
                 then { partOf = [ "kmonad.target" ]; }
                 else { inherit wantedBy; });
         };
+
         required-units = map (mk-kmonad-service { is-optional=false; }) cfg.configfiles;
+
         optional-units = map (mk-kmonad-service { is-optional=true;  }) cfg.configfiles;
 
-      in mkIf cfg.enable ({ services = listToAttrs (required-units ++ optional-units); } // (attrsets.optionalAttrs
-        make-group { targets.kmonad = mk-kmonad-target (required-units ++ optional-units); }));
+      in
+        mkIf cfg.enable ({
+            # convert our output [{name=_; value=_;}] map to {name=value;} for the systemd module
+            services = listToAttrs (required-units ++ optional-units);
+          } // (
+            # additionally, if make-group is true, add the targets.kmonad attr and pass in all units
+            attrsets.optionalAttrs make-group
+              { targets.kmonad = mk-kmonad-target (required-units ++ optional-units); })
+          );
   };
 }


### PR DESCRIPTION
A (breaking) change to spawn one kmonad instance for each config file a user has written.

this also ensures that the service is human-readable (ie: `kmonad-my.kbd`) -- I _think_ nixos won't let you write systemd units with identical names, so the case of two `my.kbd` configs at different paths is implicitly covered (and will error).

 