### PR TITLE
Make around-next only affect the next button

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,5 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 ### [Added]
 - Added default compose sequence for Ü
 
+### [Changed]
+- Fixed a bug in `around-next` that caused it to affect more than just
+  the next button
+
 ## [0.4.1] - 2020-09-12
 - First release where we start tracking changes.

--- a/src/KMonad/Button.hs
+++ b/src/KMonad/Button.hs
@@ -177,9 +177,10 @@ around outer inner = Button
 aroundNext ::
      Button -- ^ The outer 'Button'
   -> Button -- ^ The resulting 'Button'
-aroundNext b = onPress $ await isPress $ \e -> do
+aroundNext b = onPress $ await isPress $ \_ -> do
   runAction $ b^.pressAction
-  await (isReleaseOf $ e^.keycode) $ \_ -> do
+  -- Wait for the next *event*, regardless of what it is
+  await (pure True) $ \_ -> do
     runAction $ b^.releaseAction
     pure NoCatch
   pure NoCatch
@@ -351,5 +352,3 @@ layerNext :: LayerTag -> Button
 layerNext t = onPress $ do
   layerOp (PushLayer t)
   await isPress (\_ -> whenDone (layerOp $ PopLayer t) *> pure NoCatch)
-
-


### PR DESCRIPTION
Closes #166

I'm not merging this myself as, while it's technically a bug fix, it
possibly introduces a regression; see the discussion in #166 for all
information.

Before this change, `around-next` was able to change more buttons than just
the very next one, provided the next button was released after some
other buttons were pressed.  For example, suppose we had

    (defalias
      nsh (around-next sft))

Then the old behaviour would give

    T@nsh Ta Tb       ==> Ab
    T@nsh Pa Pb Ra Rb ==> AB

while the intended behaviour (and the one that this commit introduces)
would be

    T@nsh Ta Tb       ==> Ab
    T@nsh Pa Pb Ra Rb ==> Ab
