### PR TITLE
[WIP] Add tap-repeat

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 
 ## [Unreleased]
 
+### [Added]
+- `tap-release` support, to emulate QMKs default behaviour with regards
+  to [tapping force hold](https://beta.docs.qmk.fm/using-qmk/software-features/tap_hold#tapping-force-hold)
+
 ### [Fixed]
 - Fixed compilation error under Mac, having to do with typo in Keycodes
 

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -52,8 +52,7 @@
   include at least an 'input' field and an 'output' field. These describe how
   KMonad captures its inputs and how it emits its outputs.
 
-  First, let's go over the optional, non-OS specific settings. Currently there is
-  only 2:
+  First, let's go over the optional, non-OS specific settings.
 
   - fallthrough: `true` or `false`, defaults to `false`
 
@@ -73,6 +72,26 @@
 
     is a thing. For more information on the `cmd-button' function, see the
     section on Command buttons below.
+
+  - tap-repeat: *number*, defaults to not specified!
+
+    This is an inverted version of QMKs `TAPPING_FORCE_HOLD'[1], meaning that
+    the `TAPPING_FORCE_HOLD' functionality is really the default in kmonad and
+    that by setting `tap-repeat' one may achieve QMKs default behaviour. If
+    this is specified and a tap-* style button is quickly tapped and then,
+    within the specified timeout, pressed again and held down, we just press
+    the tap button, allowing the OS to repeat it as needed. This is useful for
+    people who want to bind modifier keys to their home row, but may still want
+    to repeat that key at times. Suppose we had
+
+      (defalias
+        jc (tap-hold-next-release 2000 j lctl))
+
+    bound to `j'. With `tap-repeat', one may execute a quick `Tj Pj` to
+    repeatedly press `j' (and thus, for example, scroll down when using
+    VIM-style keybindings).
+
+    [1] https://beta.docs.qmk.fm/using-qmk/software-features/tap_hold#tapping-force-hold
 
   Secondly, let's go over how to specify the `input` and `output` fields of a
   `defcfg` block. This differs between OS'es, and so do the capabilities of
@@ -541,7 +560,7 @@
   These two operations together, however, are very useful for activating a
   permanent overlay for a while. This technique is illustrated in the tap-hold
   overlay a bit further down.
-   
+
 
   -------------------------------------------------------------------------- |#
 

--- a/src/KMonad/Action.hs
+++ b/src/KMonad/Action.hs
@@ -147,6 +147,8 @@ class Monad m => MonadKIO m where
   inject     :: KeyEvent -> m ()
   -- | Run a shell-command
   shellCmd   :: Text -> m ()
+  -- | Whether tapping tap buttons should repeat them, with a timeout
+  tapRepeat  :: m (Maybe Milliseconds)
 
 -- | 'MonadKIO' contains the additional bindings that get added when we are
 -- currently processing a button.

--- a/src/KMonad/App.hs
+++ b/src/KMonad/App.hs
@@ -58,6 +58,7 @@ data AppCfg = AppCfg
   , _firstLayer   :: LayerTag          -- ^ Active layer when KMonad starts
   , _fallThrough  :: Bool              -- ^ Whether uncaught events should be emitted or not
   , _allowCmd     :: Bool              -- ^ Whether shell-commands are allowed
+  , _tpRepeat     :: Maybe Milliseconds-- ^ Tapping a tap button repeats it, with timeout
   }
 makeClassy ''AppCfg
 
@@ -66,7 +67,7 @@ makeClassy ''AppCfg
 data AppEnv = AppEnv
   { -- Stored copy of cfg
     _keAppCfg   :: AppCfg
-   
+
     -- General IO
   , _keLogFunc  :: LogFunc
   , _keySink    :: KeySink
@@ -224,6 +225,9 @@ instance (HasAppEnv e, HasAppCfg e, HasLogFunc e) => MonadKIO (RIO e) where
       void . spawnCommand . unpack $ t
     else
       logInfo $ "Received but not running: " <> display t
+
+  -- Tapping a tap button repeats it, with timeout
+  tapRepeat = view tpRepeat
 
 --------------------------------------------------------------------------------
 -- $kenv

--- a/src/KMonad/Args.hs
+++ b/src/KMonad/Args.hs
@@ -59,6 +59,7 @@ loadConfig cmd = do
     , _firstLayer   = _fstL  cgt
     , _fallThrough  = _flt   cgt
     , _allowCmd     = _allow cgt
+    , _tpRepeat     = _tpRpt cgt
     }
 
 -- | Join the options given from the command line with the one read from the

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -164,6 +164,7 @@ joinConfig' = do
   o  <- getO
   ft <- getFT
   al <- getAllow
+  tr <- getTpRpt
 
   -- Extract the other blocks and join them into a keymap
   let als = extract _KDefAlias    $ es
@@ -178,6 +179,7 @@ joinConfig' = do
     , _fstL  = fl
     , _flt   = ft
     , _allow = al
+    , _tpRpt = fromIntegral <$> tr
     }
 
 --------------------------------------------------------------------------------
@@ -238,6 +240,15 @@ getAllow = do
     Right b        -> pure b
     Left None      -> pure False
     Left Duplicate -> throwError $ DuplicateSetting "allow-cmd"
+
+-- | Extract the tap-repeat setting
+getTpRpt :: J (Maybe Int)
+getTpRpt = do
+  cfg <- oneBlock "defcfg" _KDefCfg
+  case onlyOne . extract _STapRepeat $ cfg of
+    Right b        -> pure b
+    Left None      -> pure Nothing
+    Left Duplicate -> throwError $ DuplicateSetting "tap-repeat"
 
 #ifdef linux_HOST_OS
 

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -332,6 +332,7 @@ settingP = let f s p = symbol s *> p in
     , SInitStr     <$> f "init"        textP
     , SFallThrough <$> f "fallthrough" bool
     , SAllowCmd    <$> f "allow-cmd"   bool
+    , STapRepeat   <$> f "tap-repeat"  (optional numP)
     ])
 
 --------------------------------------------------------------------------------

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -118,6 +118,7 @@ data CfgToken = CfgToken
   , _fstL  :: LayerTag                          -- ^ Name of initial layer
   , _flt   :: Bool                              -- ^ How to deal with unhandled events
   , _allow :: Bool                              -- ^ Whether to allow shell commands
+  , _tpRpt :: (Maybe Milliseconds)              -- ^ Tapping tap buttons repeats them
   }
 makeClassy ''CfgToken
 
@@ -169,6 +170,7 @@ data DefSetting
   | SInitStr     Text
   | SFallThrough Bool
   | SAllowCmd    Bool
+  | STapRepeat   (Maybe Int)
   deriving Show
 makeClassyPrisms ''DefSetting
 
@@ -182,6 +184,7 @@ instance Eq DefSetting where
   SInitStr{}     == SInitStr{}     = True
   SFallThrough{} == SFallThrough{} = True
   SAllowCmd{}    == SAllowCmd{}    = True
+  STapRepeat{}   == STapRepeat{}   = True
   _              == _              = False
 
 -- | A list of different 'DefSetting' values


### PR DESCRIPTION
Closes #163 

This adds a `tap-repeat` option, effectively providing what QMK is doing
by default with regards to [tapping force hold](https://beta.docs.qmk.fm/using-qmk/software-features/tap_hold#tapping-force-hold)

A few notes on the implementation 

  - I'm also not sure if one should add a `tapRelease` field.  I thought
    that, since it's a global setting, this would make more sense than
    adding an additional argument to every `tap-*` style button, but one
    may just as well argue that these kind of properties *should* be
    explicitly passed to the respective functions.

There's still one bug that needs fixing before this is in a mergeable state (I'm getting hit by life right now, so I'm not sure when I'll get to this): 

> Another issue only with your branch:
> 
> When I type quickly `f`, `j`, `f` (mapped to `i`, `t`, `i` in my layout), I get `i`, `i`, `t`.

here, the buttons in questions are bound to `tap-hold-*` style buttons themselves; I think the issue happens because we spawn a new hook to look for a tapped press, making holding the event processing in a tap-hold ineffective.


