### PR TITLE
Use conventional XDG config directory

### DIFF
--- a/startup/kmonad.service
+++ b/startup/kmonad.service
@@ -4,7 +4,7 @@ Description=kmonad keyboard config
 [Service]
 Restart=always
 RestartSec=3
-ExecStart=/usr/bin/kmonad %E/homemod.kbd
+ExecStart=/usr/bin/kmonad %E/kmonad/config.kbd
 Nice=-20
 
 [Install]


### PR DESCRIPTION
Minor change to the recent systemd unit addition: use `~/.config/kmonad/`  (or `/etc/kmonad/` if called as system service) as configuration directory instead of `~/.config/` (or `/etc/` if called as system service). 