### PR TITLE
Added led pass through to kmonad for linux uinput

### DIFF
--- a/src/KMonad/App.hs
+++ b/src/KMonad/App.hs
@@ -103,8 +103,8 @@ initAppEnv cfg = do
   lgf <- view logFuncL
 
   -- Acquire the keysource and keysink
-  snk <- using $ cfg^.keySinkDev
   src <- using $ cfg^.keySourceDev
+  snk <- using $ cfg^.keySinkDev
 
   -- Initialize the pull-chain components
   dsp <- Dp.mkDispatch $ awaitKey src

--- a/src/KMonad/Keyboard/IO/Linux/DeviceSource.hs
+++ b/src/KMonad/Keyboard/IO/Linux/DeviceSource.hs
@@ -131,7 +131,7 @@ lsOpen :: (HasLogFunc e)
   -> FilePath      -- ^ The path to the device file
   -> RIO e DeviceFile
 lsOpen pr pt = do
-  h  <- liftIO . openFd pt ReadOnly Nothing $
+  h  <- liftIO . openFd pt ReadWrite Nothing $
     OpenFileFlags False False False False False
   hd <- liftIO $ fdToHandle h
   logInfo $ "Initiating ioctl grab"

--- a/src/KMonad/Keyboard/IO/Linux/UinputSink.hs
+++ b/src/KMonad/Keyboard/IO/Linux/UinputSink.hs
@@ -138,7 +138,7 @@ send_event u (Fd h) e@(LinuxKeyEvent (s', ns', typ, c, val)) = do
 -- | Create a new UinputSink
 usOpen :: HasLogFunc e => UinputCfg -> RIO e UinputSink
 usOpen c = do
-  fd <- liftIO . openFd "/dev/uinput" WriteOnly Nothing $
+  fd <- liftIO . openFd "/dev/uinput" ReadWrite Nothing $
     OpenFileFlags False False False True False
   logInfo "Registering Uinput device"
   acquire_uinput_keysink fd c `onErr` UinputRegistrationError (c ^. keyboardName)


### PR DESCRIPTION
As mentioned in https://github.com/david-janssen/kmonad/issues/198, grabbing the `uinput` device blocks the access of the leds exposed by the device through `/sys/class/leds/` and similar (writing `EV_LED` event). 

This pull request is a very rough patch for this problem. 

It creates a thread that polls from the sink for events and writes those into the source if the event was regarding leds. For this to work, the read write permissions needed to be changed, and the order of initialization of the source and sink device needed to be flipped. Otherwise the new uinput device, couldn't mirror the leds of the existing source uinput device.

This is mostly a very rough, but working proof of concept for now.