### PR TITLE
Add sticky keys

### DIFF
--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -381,6 +381,40 @@
   md4 (around % b)               ;; BEWARE: %B, not %b, do you see why?
 )
 
+#| --------------------------------------------------------------------------
+                          Optional: sticky keys
+
+  KMonad also support so called "sticky keys".  These are keys that will
+  behave as if they were pressed after just tapping them.  This behaviour
+  wears off after the next button is pressed, which makes them ideal for
+  things like a quick control or shift.  For example, tapping a sticky and
+  then pressing `abc' will result in `Abc'.
+
+  You can create these keys with the `sticky-key' keyword:
+
+    (defalias
+      slc (sticky-key 500 lctl))
+
+  The number after `sticky-key' is the timeout you want, in milliseconds.  If
+  a key is tapped and that time has passed, it won't act like it's pressed
+  down when we receive the next keypress.
+
+  It is also possible to combine sticky keys.  For example, to
+  get a sticky shift+control you can do
+
+    (defalias
+      ssc (around
+           (sticky-key 500 lsft)
+           (sticky-key 500 lctl)))
+
+  -------------------------------------------------------------------------- |#
+
+;; Let's make both shift keys sticky
+(defalias
+  sl (sticky-key 300 lsft)
+  sr (sticky-key 300 rsft))
+
+
 ;; Now we define the 'tst' button as opening and closing a bunch of layers at
 ;; the same time. If you understand why this works, you're starting to grok
 ;; KMonad.
@@ -541,7 +575,7 @@
   These two operations together, however, are very useful for activating a
   permanent overlay for a while. This technique is illustrated in the tap-hold
   overlay a bit further down.
-   
+
 
   -------------------------------------------------------------------------- |#
 
@@ -572,7 +606,7 @@
   grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
   tab  q    w    f    p    g    j    l    u    y    ;    [    ]    \
   @xcp a    r    s    t    d    h    n    e    i    o    '    ret
-  lsft z    x    c    v    b    k    m    ,    .    /    rsft
+  @sl  z    x    c    v    b    k    m    ,    .    /    @sr
   lctl @num lalt           spc            ralt rmet @sym @tst
 )
 

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -363,6 +363,7 @@ joinButton ns als =
     KPause ms          -> jst . pure $ onPress (pause ms)
     KMultiTap bs d     -> jst $ multiTap <$> go d <*> mapM f bs
       where f (ms, b) = (fi ms,) <$> go b
+    KStickyKey s d     -> jst $ stickyKey (fi s) <$> go d
 
     -- Non-action buttons
     KTrans -> pure Nothing

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -275,6 +275,7 @@ keywordButtons =
   , ("tap-macro"      , KTapMacro    <$> some buttonP)
   , ("cmd-button"     , KCommand     <$> lexeme textP <*> optional (lexeme textP))
   , ("pause"          , KPause . fromIntegral <$> numP)
+  , ("sticky-key"     , KStickyKey   <$> lexeme numP <*> buttonP)
   ]
  where
   timed :: Parser [(Int, DefButton)]

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -97,6 +97,7 @@ data DefButton
   | KLayerNext LayerTag                    -- ^ Perform next button in different layer
   | KCommand Text (Maybe Text)             -- ^ Execute a shell command on press, as well
                                            --   as possibly on release
+  | KStickyKey Int DefButton               -- ^ Act as if a button is pressed for a period of time
   | KTrans                                 -- ^ Transparent button that does nothing
   | KBlock                                 -- ^ Button that catches event
   deriving Show

--- a/src/KMonad/Button.hs
+++ b/src/KMonad/Button.hs
@@ -46,6 +46,7 @@ module KMonad.Button
   , tapNextRelease
   , tapHoldNextRelease
   , tapMacro
+  , stickyKey
   )
 where
 
@@ -352,3 +353,32 @@ layerNext :: LayerTag -> Button
 layerNext t = onPress $ do
   layerOp (PushLayer t)
   await isPress (\_ -> whenDone (layerOp $ PopLayer t) *> pure NoCatch)
+
+-- | Make a button into a sticky-key, i.e. a key that acts like it is
+-- pressed for the button after it if that button was pressed in the
+-- given timeframe.
+stickyKey :: Milliseconds -> Button -> Button
+stickyKey ms b = onPress $ go
+ where
+  go :: MonadK m => m ()
+  go = hookF InputHook $ \e -> do
+    p <- matchMy Release
+    if | p e               -> doTap    $> Catch
+         -- My own release; we act as if we were tapped
+       | not (isRelease e) -> doHold e $> Catch
+         -- The press of another button; act like we are held down
+       | otherwise         -> go       $> NoCatch
+         -- The release of some other button; ignore these
+
+  doHold :: MonadK m => KeyEvent -> m ()
+  doHold e = press b *> inject e
+
+  doTap :: MonadK m => m ()
+  doTap =
+    within ms
+           (pure isPress)  -- presses definitely happen after us
+           (pure ())
+           (\t -> (runAction $ b^.pressAction)
+               *> inject (t^.event)
+               *> after 3 (runAction $ b^.releaseAction)
+               $> Catch)


### PR DESCRIPTION
This adds very simple sticky keys.  These are keys that will behave as if they were pressed after just tapping them.  This behaviour wears off after the next button is pressed, which makes them ideal for things like a quick control or shift.  For example, tapping a sticky and then pressing `abc` will result in `Abc`.

The number after `sticky-key` is the timeout you want, in milliseconds.  If a key is tapped and that time has passed, it won't act like it's pressed down when we receive the next keypress.

One can create these keys with the `sticky-key` keyword:

``` clojure
  (defalias
    slc (sticky-key 500 lctl))
```

Closes #202 ... somewhat.  What it doesn't implement is a way to chain sticky keys, e.g. pressing sticky-ctrl and then sticky-sft should result in sticky-(ctrl-sft).  This would require a way to inspect the buttons that will be pressed when we receive a keycode, which seems (aside from weird global state hackery) to be not something that we can (easily) do with the current setup.

